### PR TITLE
Add context builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ shinobi run --issue 123
 
 `watch` や phase 分離コマンドは将来候補です。MVP の公開 CLI には含めません。
 
-現在の実装では foundations に加えて、`shinobi run` / `shinobi run --issue <id>` の select と start phase まで実装しています。Issue 選択、`.shinobi/run.lock` によるローカル排他、`feature/issue-<id>-<slug>` branch 作成、start 用の machine-readable comment 投稿、状態 label 正規化が動作します。context phase 以降は未実装のため、start 完了後はいったん `shinobi:needs-human` へ handoff して安全停止します。
+現在の実装では foundations に加えて、`shinobi run` / `shinobi run --issue <id>` の select と start phase まで実装しています。Issue 選択、`.shinobi/run.lock` によるローカル排他、`feature/issue-<id>-<slug>` branch 作成、start 用の machine-readable comment 投稿、状態 label 正規化が動作します。context builder は Issue とローカル knowledge から最小実行コンテキストを構築できますが、run phase への統合は未実装です。start 完了後はいったん `shinobi:needs-human` へ handoff して安全停止します。
 
 ## ドキュメント構成
 
@@ -87,4 +87,4 @@ shinobi run --issue 123
 
 ## 現在の状態
 
-このリポジトリは foundations 実装に加え、`run` の start phase までを持ちます。現在は `.shinobi/` の初期化、ローカル state/config の保存、`status` のローカル表示、`run` の issue 選択、stale/live lock 判定、branch 作成、start 用 comment 投稿、GitHub label の start 遷移と安全 handoff までを持ちます。context 以降、PR 自動化、review loop はこれから実装します。
+このリポジトリは foundations 実装に加え、`run` の start phase と context builder を持ちます。現在は `.shinobi/` の初期化、ローカル state/config の保存、`status` のローカル表示、`run` の issue 選択、stale/live lock 判定、branch 作成、start 用 comment 投稿、GitHub label の start 遷移、安全 handoff、Issue 由来の最小 context 構築までを持ちます。context phase の run 統合、PR 自動化、review loop はこれから実装します。

--- a/src/shinobi/context_builder.py
+++ b/src/shinobi/context_builder.py
@@ -121,7 +121,7 @@ def parse_markdown_sections(body: str) -> dict[str, list[str]]:
         heading = parse_heading(line)
         if heading is not None:
             if current_key is not None:
-                sections[current_key] = normalize_section_lines(current_lines)
+                append_section(sections, current_key, current_lines)
             current_key = section_key_for_heading(heading)
             current_lines = []
             continue
@@ -130,9 +130,15 @@ def parse_markdown_sections(body: str) -> dict[str, list[str]]:
             current_lines.append(line)
 
     if current_key is not None:
-        sections[current_key] = normalize_section_lines(current_lines)
+        append_section(sections, current_key, current_lines)
 
     return sections
+
+
+def append_section(
+    sections: dict[str, list[str]], key: str, lines: list[str]
+) -> None:
+    sections.setdefault(key, []).extend(normalize_section_lines(lines))
 
 
 def parse_heading(line: str) -> str | None:
@@ -200,12 +206,19 @@ def extract_candidate_files(body: str) -> list[str]:
 
     for match in PATH_PATTERN.finditer(body):
         raw_path = match.group(1) or match.group(2) or ""
-        path = raw_path.strip()
+        path = normalize_path_reference(raw_path)
         if not path or should_ignore_candidate_path(path):
             continue
         candidates.append(path)
 
     return unique_items(candidates)
+
+
+def normalize_path_reference(path: str) -> str:
+    normalized = path.strip()
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
 
 
 def extract_paths_from_sections(

--- a/src/shinobi/context_builder.py
+++ b/src/shinobi/context_builder.py
@@ -65,7 +65,7 @@ def build_mission_context(root: Path, issue: dict) -> MissionContext:
             *issue_paths,
         ]
     )
-    needs_human_review_reason = broad_scope_reason(body, candidate_files)
+    needs_human_review_reason = broad_scope_reason(sections, candidate_files)
 
     return MissionContext(
         issue_number=int(issue["number"]),
@@ -204,13 +204,20 @@ def derive_prohibited_actions(sections: dict[str, list[str]]) -> list[str]:
     return unique_items(prohibited)
 
 
-def broad_scope_reason(body: str, candidate_files: list[str]) -> str | None:
+def broad_scope_reason(
+    sections: dict[str, list[str]], candidate_files: list[str]
+) -> str | None:
     if not candidate_files:
         return "issue body does not name candidate files"
 
-    lowered_body = body.lower()
+    scope_text = "\n".join(
+        item
+        for key in ("purpose", "requirements", "targets", "notes")
+        for item in sections.get(key, [])
+    )
+    lowered_scope_text = scope_text.lower()
     for word in HIGH_RISK_WORDS:
-        if word.lower() in lowered_body:
+        if word.lower() in lowered_scope_text:
             return f"issue body contains broad scope marker: {word}"
 
     return None

--- a/src/shinobi/context_builder.py
+++ b/src/shinobi/context_builder.py
@@ -18,7 +18,15 @@ SECTION_ALIASES = {
 }
 
 PATH_PATTERN = re.compile(r"`([^`\n]+)`|(?:^|\s)([A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+)")
-HIGH_RISK_WORDS = ("全体", "全ファイル", "repo 全体", "repository-wide", "必要に応じて広く")
+HIGH_RISK_WORDS = (
+    "全ファイル",
+    "全体修正",
+    "全体リファクタ",
+    "repo 全体を変更",
+    "repo 全体を修正",
+    "repository-wide",
+    "必要に応じて広く",
+)
 LOCAL_KNOWLEDGE_PATHS = {".shinobi/summary.md", ".shinobi/decisions.md"}
 
 

--- a/src/shinobi/context_builder.py
+++ b/src/shinobi/context_builder.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .state_store import StateStore
+
+
+SECTION_ALIASES = {
+    "purpose": ("目的", "goal", "purpose"),
+    "requirements": ("要件", "requirements"),
+    "completion_criteria": ("完了条件", "acceptance criteria", "done"),
+    "scope_out": ("スコープ外", "out of scope", "scope out"),
+    "notes": ("注意点", "notes", "cautions"),
+    "targets": ("対象", "target", "targets", "files"),
+    "prohibited": ("禁止事項", "やってはいけないこと", "prohibited"),
+}
+
+PATH_PATTERN = re.compile(r"`([^`\n]+)`|(?:^|\s)([A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+)")
+HIGH_RISK_WORDS = ("全体", "全ファイル", "repo 全体", "repository-wide", "必要に応じて広く")
+LOCAL_KNOWLEDGE_PATHS = {".shinobi/summary.md", ".shinobi/decisions.md"}
+
+
+@dataclass(frozen=True)
+class MissionContext:
+    issue_number: int
+    issue_title: str
+    mission_summary: str
+    completion_criteria: list[str]
+    scope_out: list[str]
+    reference_files: list[str]
+    candidate_files: list[str]
+    prohibited_actions: list[str]
+    summary: str
+    decisions: str
+    requirements: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    needs_human_review: bool = False
+    needs_human_review_reason: str | None = None
+
+
+def build_mission_context(root: Path, issue: dict) -> MissionContext:
+    body = str(issue.get("body") or "")
+    sections = parse_markdown_sections(body)
+    store = StateStore(root)
+
+    summary = read_optional_text(store.paths.summary_path)
+    decisions = read_optional_text(store.paths.decisions_path)
+    issue_paths = extract_candidate_files(body)
+    target_paths = extract_candidate_files("\n".join(sections.get("targets", [])))
+    candidate_files = filter_local_knowledge_paths(target_paths or issue_paths)
+    reference_files = unique_items(
+        [
+            ".shinobi/summary.md",
+            ".shinobi/decisions.md",
+            *issue_paths,
+        ]
+    )
+    needs_human_review_reason = broad_scope_reason(body, candidate_files)
+
+    return MissionContext(
+        issue_number=int(issue["number"]),
+        issue_title=str(issue.get("title") or ""),
+        mission_summary=first_paragraph(
+            sections.get("purpose", []),
+            fallback=str(issue.get("title") or ""),
+        ),
+        completion_criteria=sections.get("completion_criteria", []),
+        scope_out=sections.get("scope_out", []),
+        reference_files=reference_files,
+        candidate_files=candidate_files,
+        prohibited_actions=derive_prohibited_actions(sections),
+        summary=summary,
+        decisions=decisions,
+        requirements=sections.get("requirements", []),
+        notes=sections.get("notes", []),
+        needs_human_review=needs_human_review_reason is not None,
+        needs_human_review_reason=needs_human_review_reason,
+    )
+
+
+def parse_markdown_sections(body: str) -> dict[str, list[str]]:
+    sections: dict[str, list[str]] = {}
+    current_key: str | None = None
+    current_lines: list[str] = []
+
+    for line in body.splitlines():
+        heading = parse_heading(line)
+        if heading is not None:
+            if current_key is not None:
+                sections[current_key] = normalize_section_lines(current_lines)
+            current_key = section_key_for_heading(heading)
+            current_lines = []
+            continue
+
+        if current_key is not None:
+            current_lines.append(line)
+
+    if current_key is not None:
+        sections[current_key] = normalize_section_lines(current_lines)
+
+    return sections
+
+
+def parse_heading(line: str) -> str | None:
+    match = re.match(r"^\s{0,3}#{1,6}\s+(.+?)\s*$", line)
+    if match is None:
+        return None
+    return match.group(1).strip().lower()
+
+
+def section_key_for_heading(heading: str) -> str:
+    normalized = heading.strip().lower()
+    for key, aliases in SECTION_ALIASES.items():
+        if any(alias.lower() == normalized for alias in aliases):
+            return key
+    return normalized
+
+
+def normalize_section_lines(lines: list[str]) -> list[str]:
+    items: list[str] = []
+    paragraph: list[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            flush_paragraph(items, paragraph)
+            continue
+
+        list_item = re.match(r"^[-*]\s+(.*)$", stripped)
+        ordered_item = re.match(r"^\d+[.)]\s+(.*)$", stripped)
+        if list_item or ordered_item:
+            flush_paragraph(items, paragraph)
+            item = list_item.group(1) if list_item else ordered_item.group(1)
+            items.append(item.strip())
+            continue
+
+        paragraph.append(stripped)
+
+    flush_paragraph(items, paragraph)
+    return items
+
+
+def flush_paragraph(items: list[str], paragraph: list[str]) -> None:
+    if not paragraph:
+        return
+    items.append(" ".join(paragraph).strip())
+    paragraph.clear()
+
+
+def first_paragraph(items: list[str], *, fallback: str) -> str:
+    for item in items:
+        if item:
+            return item
+    return fallback
+
+
+def read_optional_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return ""
+
+
+def extract_candidate_files(body: str) -> list[str]:
+    candidates: list[str] = []
+
+    for match in PATH_PATTERN.finditer(body):
+        raw_path = match.group(1) or match.group(2) or ""
+        path = raw_path.strip()
+        if not path or should_ignore_candidate_path(path):
+            continue
+        candidates.append(path)
+
+    return unique_items(candidates)
+
+
+def filter_local_knowledge_paths(paths: list[str]) -> list[str]:
+    return [path for path in paths if path not in LOCAL_KNOWLEDGE_PATHS]
+
+
+def should_ignore_candidate_path(path: str) -> bool:
+    if " " in path:
+        return True
+    if path.startswith(("http://", "https://")):
+        return True
+    if path in {".", ".."}:
+        return True
+    return not ("/" in path or "." in path)
+
+
+def derive_prohibited_actions(sections: dict[str, list[str]]) -> list[str]:
+    prohibited = list(sections.get("prohibited", []))
+    prohibited.extend(f"Do not include: {item}" for item in sections.get("scope_out", []))
+    return unique_items(prohibited)
+
+
+def broad_scope_reason(body: str, candidate_files: list[str]) -> str | None:
+    if not candidate_files:
+        return "issue body does not name candidate files"
+
+    lowered_body = body.lower()
+    for word in HIGH_RISK_WORDS:
+        if word.lower() in lowered_body:
+            return f"issue body contains broad scope marker: {word}"
+
+    return None
+
+
+def unique_items(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    unique: list[str] = []
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        unique.append(item)
+    return unique

--- a/src/shinobi/context_builder.py
+++ b/src/shinobi/context_builder.py
@@ -73,15 +73,16 @@ def build_mission_context(root: Path, issue: dict) -> MissionContext:
         keys=REFERENCE_SOURCE_SECTIONS,
         fallback=body,
     )
-    target_paths = extract_candidate_files("\n".join(sections.get("targets", [])))
+    target_paths = filter_local_knowledge_paths(
+        extract_candidate_files("\n".join(sections.get("targets", [])))
+    )
     fallback_candidate_paths = extract_paths_from_sections(
         sections,
         keys=CANDIDATE_SOURCE_SECTIONS,
         fallback=body,
     )
-    candidate_files = filter_local_knowledge_paths(
-        target_paths or fallback_candidate_paths
-    )
+    fallback_candidate_paths = filter_local_knowledge_paths(fallback_candidate_paths)
+    candidate_files = target_paths or fallback_candidate_paths
     reference_files = unique_items(
         [
             ".shinobi/summary.md",
@@ -225,7 +226,11 @@ def extract_paths_from_sections(
     sections: dict[str, list[str]], *, keys: tuple[str, ...], fallback: str
 ) -> list[str]:
     selected_text = "\n".join(item for key in keys for item in sections.get(key, []))
-    return extract_candidate_files(selected_text or fallback)
+    if selected_text:
+        return extract_candidate_files(selected_text)
+    if sections:
+        return []
+    return extract_candidate_files(fallback)
 
 
 def filter_local_knowledge_paths(paths: list[str]) -> list[str]:

--- a/src/shinobi/context_builder.py
+++ b/src/shinobi/context_builder.py
@@ -28,6 +28,19 @@ HIGH_RISK_WORDS = (
     "必要に応じて広く",
 )
 LOCAL_KNOWLEDGE_PATHS = {".shinobi/summary.md", ".shinobi/decisions.md"}
+CANDIDATE_SOURCE_SECTIONS = (
+    "purpose",
+    "requirements",
+    "completion_criteria",
+    "notes",
+)
+REFERENCE_SOURCE_SECTIONS = (
+    "purpose",
+    "requirements",
+    "completion_criteria",
+    "notes",
+    "targets",
+)
 
 
 @dataclass(frozen=True)
@@ -55,9 +68,20 @@ def build_mission_context(root: Path, issue: dict) -> MissionContext:
 
     summary = read_optional_text(store.paths.summary_path)
     decisions = read_optional_text(store.paths.decisions_path)
-    issue_paths = extract_candidate_files(body)
+    issue_paths = extract_paths_from_sections(
+        sections,
+        keys=REFERENCE_SOURCE_SECTIONS,
+        fallback=body,
+    )
     target_paths = extract_candidate_files("\n".join(sections.get("targets", [])))
-    candidate_files = filter_local_knowledge_paths(target_paths or issue_paths)
+    fallback_candidate_paths = extract_paths_from_sections(
+        sections,
+        keys=CANDIDATE_SOURCE_SECTIONS,
+        fallback=body,
+    )
+    candidate_files = filter_local_knowledge_paths(
+        target_paths or fallback_candidate_paths
+    )
     reference_files = unique_items(
         [
             ".shinobi/summary.md",
@@ -182,6 +206,13 @@ def extract_candidate_files(body: str) -> list[str]:
         candidates.append(path)
 
     return unique_items(candidates)
+
+
+def extract_paths_from_sections(
+    sections: dict[str, list[str]], *, keys: tuple[str, ...], fallback: str
+) -> list[str]:
+    selected_text = "\n".join(item for key in keys for item in sections.get(key, []))
+    return extract_candidate_files(selected_text or fallback)
 
 
 def filter_local_knowledge_paths(paths: list[str]) -> list[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1814,6 +1814,27 @@ class ContextBuilderTest(unittest.TestCase):
             ],
         )
 
+    def test_build_mission_context_falls_back_when_targets_are_only_local_knowledge(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            context = build_mission_context(
+                Path(tmp_dir),
+                {
+                    "number": 28,
+                    "title": "Context task",
+                    "body": (
+                        "## 対象\n"
+                        "- `.shinobi/summary.md`\n\n"
+                        "## 要件\n"
+                        "- `src/shinobi/context_builder.py` を更新\n"
+                    ),
+                },
+            )
+
+        self.assertEqual(context.candidate_files, ["src/shinobi/context_builder.py"])
+        self.assertFalse(context.needs_human_review)
+
     def test_build_mission_context_keeps_repeated_sections(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             context = build_mission_context(
@@ -1857,6 +1878,33 @@ class ContextBuilderTest(unittest.TestCase):
             )
 
         self.assertEqual(context.candidate_files, [])
+        self.assertTrue(context.needs_human_review)
+        self.assertEqual(
+            context.needs_human_review_reason,
+            "issue body does not name candidate files",
+        )
+
+    def test_build_mission_context_does_not_fallback_to_scope_out_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            context = build_mission_context(
+                Path(tmp_dir),
+                {
+                    "number": 99,
+                    "title": "Scoped task",
+                    "body": (
+                        "## スコープ外\n"
+                        "- `src/shinobi/context_builder.py` は変更しない\n\n"
+                        "## 禁止事項\n"
+                        "- `docs/architecture.md` を編集しない\n"
+                    ),
+                },
+            )
+
+        self.assertEqual(context.candidate_files, [])
+        self.assertEqual(
+            context.reference_files,
+            [".shinobi/summary.md", ".shinobi/decisions.md"],
+        )
         self.assertTrue(context.needs_human_review)
         self.assertEqual(
             context.needs_human_review_reason,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1789,6 +1789,62 @@ class ContextBuilderTest(unittest.TestCase):
         self.assertEqual(context.candidate_files, ["docs/mvp-design.md"])
         self.assertIn(".shinobi/summary.md", context.reference_files)
 
+    def test_build_mission_context_excludes_relative_local_knowledge_from_candidates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            context = build_mission_context(
+                Path(tmp_dir),
+                {
+                    "number": 28,
+                    "title": "Context task",
+                    "body": (
+                        "## 要件\n"
+                        "- `./.shinobi/summary.md` を読む\n"
+                        "- `./docs/mvp-design.md` を読む\n"
+                    ),
+                },
+            )
+
+        self.assertEqual(context.candidate_files, ["docs/mvp-design.md"])
+        self.assertEqual(
+            context.reference_files,
+            [
+                ".shinobi/summary.md",
+                ".shinobi/decisions.md",
+                "docs/mvp-design.md",
+            ],
+        )
+
+    def test_build_mission_context_keeps_repeated_sections(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            context = build_mission_context(
+                Path(tmp_dir),
+                {
+                    "number": 28,
+                    "title": "Context task",
+                    "body": (
+                        "## 要件\n"
+                        "- `src/shinobi/context_builder.py` を追加\n\n"
+                        "## 要件\n"
+                        "- `tests/test_cli.py` を更新\n"
+                    ),
+                },
+            )
+
+        self.assertEqual(
+            context.requirements,
+            [
+                "`src/shinobi/context_builder.py` を追加",
+                "`tests/test_cli.py` を更新",
+            ],
+        )
+        self.assertEqual(
+            context.candidate_files,
+            [
+                "src/shinobi/context_builder.py",
+                "tests/test_cli.py",
+            ],
+        )
+
     def test_build_mission_context_flags_missing_candidate_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             context = build_mission_context(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1807,6 +1807,35 @@ class ContextBuilderTest(unittest.TestCase):
             "issue body does not name candidate files",
         )
 
+    def test_build_mission_context_ignores_scope_out_paths_as_candidates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            context = build_mission_context(
+                Path(tmp_dir),
+                {
+                    "number": 99,
+                    "title": "Scoped task",
+                    "body": (
+                        "## 目的\n"
+                        "小さな修正を行う\n\n"
+                        "## スコープ外\n"
+                        "- `src/shinobi/context_builder.py` は変更しない\n\n"
+                        "## 禁止事項\n"
+                        "- `docs/architecture.md` を編集しない\n"
+                    ),
+                },
+            )
+
+        self.assertEqual(context.candidate_files, [])
+        self.assertEqual(
+            context.reference_files,
+            [".shinobi/summary.md", ".shinobi/decisions.md"],
+        )
+        self.assertTrue(context.needs_human_review)
+        self.assertEqual(
+            context.needs_human_review_reason,
+            "issue body does not name candidate files",
+        )
+
     def test_build_mission_context_does_not_flag_negative_repo_wide_reference(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             context = build_mission_context(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1807,6 +1807,47 @@ class ContextBuilderTest(unittest.TestCase):
             "issue body does not name candidate files",
         )
 
+    def test_build_mission_context_does_not_flag_negative_repo_wide_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            context = build_mission_context(
+                Path(tmp_dir),
+                {
+                    "number": 28,
+                    "title": "Context task",
+                    "body": (
+                        "## 対象\n"
+                        "- `src/shinobi/context_builder.py`\n\n"
+                        "## 完了条件\n"
+                        "- repo 全体を読まない前提がコードで守られている\n"
+                    ),
+                },
+            )
+
+        self.assertFalse(context.needs_human_review)
+        self.assertIsNone(context.needs_human_review_reason)
+
+    def test_build_mission_context_flags_explicit_broad_scope_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            context = build_mission_context(
+                Path(tmp_dir),
+                {
+                    "number": 99,
+                    "title": "Broad task",
+                    "body": (
+                        "## 対象\n"
+                        "- `src/shinobi/context_builder.py`\n\n"
+                        "## 注意点\n"
+                        "- repository-wide cleanup を含む\n"
+                    ),
+                },
+            )
+
+        self.assertTrue(context.needs_human_review)
+        self.assertEqual(
+            context.needs_human_review_reason,
+            "issue body contains broad scope marker: repository-wide",
+        )
+
 
 class GitHubClientTest(unittest.TestCase):
     def test_get_issue_surfaces_parse_failure_with_context(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from shinobi import cli
 from shinobi.config import discover_repo_slug
+from shinobi.context_builder import build_mission_context
 from shinobi.github_client import GitHubClient, GitHubClientError
 from shinobi.mission_start import (
     MissionStartError,
@@ -1693,6 +1694,118 @@ class MissionStartTest(unittest.TestCase):
                     },
                     now=now,
                 )
+
+
+class ContextBuilderTest(unittest.TestCase):
+    def test_build_mission_context_reads_issue_and_local_knowledge(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            store = StateStore(root)
+            store.paths.shinobi_dir.mkdir()
+            store.paths.summary_path.write_text("summary text\n", encoding="utf-8")
+            store.paths.decisions_path.write_text("decision text\n", encoding="utf-8")
+
+            context = build_mission_context(
+                root,
+                {
+                    "number": 28,
+                    "title": "[TASK] context_builder を実装する",
+                    "body": (
+                        "## 目的\n"
+                        "Issue とローカル知識から最小実行コンテキストを生成する。\n\n"
+                        "## 対象\n"
+                        "- `src/shinobi/context_builder.py`\n"
+                        "- `tests/test_cli.py`\n\n"
+                        "## 要件\n"
+                        "- Issue 本文を読む\n"
+                        "- `.shinobi/summary.md` を読む\n\n"
+                        "## 完了条件\n"
+                        "- context builder が構造化データを返す\n\n"
+                        "## スコープ外\n"
+                        "- AI 実装エージェント呼び出し\n"
+                    ),
+                },
+            )
+
+        self.assertEqual(context.issue_number, 28)
+        self.assertEqual(
+            context.mission_summary,
+            "Issue とローカル知識から最小実行コンテキストを生成する。",
+        )
+        self.assertEqual(
+            context.candidate_files,
+            [
+                "src/shinobi/context_builder.py",
+                "tests/test_cli.py",
+            ],
+        )
+        self.assertEqual(
+            context.reference_files,
+            [
+                ".shinobi/summary.md",
+                ".shinobi/decisions.md",
+                "src/shinobi/context_builder.py",
+                "tests/test_cli.py",
+            ],
+        )
+        self.assertEqual(context.summary, "summary text\n")
+        self.assertEqual(context.decisions, "decision text\n")
+        self.assertEqual(
+            context.completion_criteria,
+            ["context builder が構造化データを返す"],
+        )
+        self.assertEqual(
+            context.prohibited_actions,
+            ["Do not include: AI 実装エージェント呼び出し"],
+        )
+        self.assertFalse(context.needs_human_review)
+
+    def test_build_mission_context_treats_missing_knowledge_as_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            context = build_mission_context(
+                Path(tmp_dir),
+                {
+                    "number": 28,
+                    "title": "Context task",
+                    "body": "## 対象\n- `src/shinobi/context_builder.py`\n",
+                },
+            )
+
+        self.assertEqual(context.summary, "")
+        self.assertEqual(context.decisions, "")
+        self.assertEqual(context.mission_summary, "Context task")
+
+    def test_build_mission_context_excludes_local_knowledge_from_candidates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            context = build_mission_context(
+                Path(tmp_dir),
+                {
+                    "number": 28,
+                    "title": "Context task",
+                    "body": "## 要件\n- `.shinobi/summary.md` を読む\n- `docs/mvp-design.md` を読む\n",
+                },
+            )
+
+        self.assertEqual(context.candidate_files, ["docs/mvp-design.md"])
+        self.assertIn(".shinobi/summary.md", context.reference_files)
+
+    def test_build_mission_context_flags_missing_candidate_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            context = build_mission_context(
+                Path(tmp_dir),
+                {
+                    "number": 99,
+                    "title": "Broad task",
+                    "body": "## 目的\nいい感じに直す\n",
+                },
+            )
+
+        self.assertEqual(context.candidate_files, [])
+        self.assertTrue(context.needs_human_review)
+        self.assertEqual(
+            context.needs_human_review_reason,
+            "issue body does not name candidate files",
+        )
 
 
 class GitHubClientTest(unittest.TestCase):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1826,6 +1826,29 @@ class ContextBuilderTest(unittest.TestCase):
         self.assertFalse(context.needs_human_review)
         self.assertIsNone(context.needs_human_review_reason)
 
+    def test_build_mission_context_does_not_flag_scope_out_broad_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            context = build_mission_context(
+                Path(tmp_dir),
+                {
+                    "number": 28,
+                    "title": "Context task",
+                    "body": (
+                        "## 対象\n"
+                        "- `src/shinobi/context_builder.py`\n\n"
+                        "## スコープ外\n"
+                        "- repo 全体を変更すること\n"
+                    ),
+                },
+            )
+
+        self.assertFalse(context.needs_human_review)
+        self.assertIsNone(context.needs_human_review_reason)
+        self.assertEqual(
+            context.prohibited_actions,
+            ["Do not include: repo 全体を変更すること"],
+        )
+
     def test_build_mission_context_flags_explicit_broad_scope_marker(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             context = build_mission_context(


### PR DESCRIPTION
## Summary
- add `context_builder` to build structured mission context from an Issue body plus `.shinobi/summary.md` and `.shinobi/decisions.md`
- extract mission summary, requirements, completion criteria, scope-out items, reference files, candidate files, and prohibited actions without scanning the repository
- keep local knowledge files as references, not edit candidates, and update README current-state wording

## Testing
- python3 -m unittest tests.test_cli.ContextBuilderTest
- python3 -m unittest tests.test_cli
- env PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m compileall src tests
- git diff --check

## Notes
- No dedicated lint/typecheck command is configured in this repo; `compileall` and full unittest were used for syntax and behavioral verification.
- `shinobi run` still hands off after start; context phase integration is out of scope for this issue.

Closes #28
