### PR TITLE
Implement publish phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ shinobi run --issue 123
 
 `watch` や phase 分離コマンドは将来候補です。MVP の公開 CLI には含めません。
 
-現在の実装では foundations に加えて、`shinobi run` / `shinobi run --issue <id>` の select と start phase まで実装しています。Issue 選択、`.shinobi/run.lock` によるローカル排他、`feature/issue-<id>-<slug>` branch 作成、start 用の machine-readable comment 投稿、状態 label 正規化が動作します。context builder は Issue とローカル knowledge から最小実行コンテキストを構築できますが、run phase への統合は未実装です。start 完了後はいったん `shinobi:needs-human` へ handoff して安全停止します。
+現在の実装では foundations に加えて、`shinobi run` / `shinobi run --issue <id>` の select / start / publish phase まで実装しています。Issue 選択、`.shinobi/run.lock` によるローカル排他、`feature/issue-<id>-<slug>` branch 作成、start 用の machine-readable comment 投稿、検証コマンド実行、branch push、draft PR 作成または更新、publish 用の label / mission-state comment 更新が動作します。context builder は Issue とローカル knowledge から最小実行コンテキストを構築できますが、run phase への統合は未実装です。
 
 ## ドキュメント構成
 
@@ -87,4 +87,4 @@ shinobi run --issue 123
 
 ## 現在の状態
 
-このリポジトリは foundations 実装に加え、`run` の start phase と context builder を持ちます。現在は `.shinobi/` の初期化、ローカル state/config の保存、`status` のローカル表示、`run` の issue 選択、stale/live lock 判定、branch 作成、start 用 comment 投稿、GitHub label の start 遷移、安全 handoff、Issue 由来の最小 context 構築までを持ちます。context phase の run 統合、PR 自動化、review loop はこれから実装します。
+このリポジトリは foundations 実装に加え、`run` の start / publish phase と context builder を持ちます。現在は `.shinobi/` の初期化、ローカル state/config の保存、`status` のローカル表示、`run` の issue 選択、stale/live lock 判定、branch 作成、start 用 comment 投稿、GitHub label の start 遷移、検証コマンド実行、branch push、draft PR 作成または更新、publish 用 comment / label / state 更新、Issue 由来の最小 context 構築までを持ちます。context phase の run 統合、review loop、自動 merge はこれから実装します。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -129,6 +129,7 @@ MVP の executor は、コード編集 agent の呼び出しではなく verific
 publish phase は start 済み mission を draft PR として公開します。
 
 - owner run の lock を確認してから publish する
+- 検証結果に `failed` または `error` が含まれる場合は push / PR 更新前に停止する
 - active branch を `origin` へ push する
 - branch に対応する既存 PR があれば更新し、なければ draft PR を作成する
 - `shinobi:reviewing` を付与し、`shinobi:risky` 以外の状態 label を正規化する

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -129,7 +129,7 @@ MVP の executor は、コード編集 agent の呼び出しではなく verific
 publish phase は start 済み mission を draft PR として公開します。
 
 - owner run の lock を確認してから publish する
-- 検証結果に `failed` または `error` が含まれる場合は push / PR 更新前に停止する
+- 検証結果に `failed` または `error` が含まれる場合は push / PR 更新前に停止し、`needs-human` へ handoff する
 - active branch を `origin` へ push する
 - branch に対応する既存 PR があれば更新し、なければ draft PR を作成する
 - `shinobi:reviewing` を付与し、`shinobi:risky` 以外の状態 label を正規化する

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,6 +130,7 @@ publish phase は start 済み mission を draft PR として公開します。
 
 - owner run の lock を確認してから publish する
 - 検証結果に `failed` または `error` が含まれる場合は push / PR 更新前に停止し、`needs-human` へ handoff する
+- 現在の Issue label に `shinobi:blocked` または `shinobi:needs-human` があれば push / PR 更新前に停止する
 - active branch を `origin` へ push する
 - branch に対応する既存 PR があれば更新し、なければ draft PR を作成する
 - `shinobi:reviewing` を付与し、`shinobi:risky` 以外の状態 label を正規化する

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,6 +94,7 @@ src/shinobi/
   issue_selector.py
   context_builder.py
   executor.py
+  mission_publish.py
   reviewer.py
   merger.py
   state_store.py
@@ -108,6 +109,7 @@ src/shinobi/
 - `issue_selector.py`: 次 Issue 選択
 - `context_builder.py`: 最小コンテキスト生成
 - `executor.py`: 実装フェーズの検証コマンド実行と結果構造化
+- `mission_publish.py`: branch push、draft PR 作成または更新、publish 状態の label / comment / state 更新
 - `reviewer.py`: review / retry 判定
 - `merger.py`: マージ可否判定
 - `state_store.py`: ローカル state 管理
@@ -121,6 +123,17 @@ MVP の executor は、コード編集 agent の呼び出しではなく verific
 - 未定義コマンドは `not_configured` として失敗結果に含める
 - コマンド起動失敗は例外で phase 全体を落とさず `error` 結果として返す
 - 後続の publish / review phase が使えるよう `ExecutionResult` に成功可否と変更要約の土台を持たせる
+
+### `mission_publish.py`
+
+publish phase は start 済み mission を draft PR として公開します。
+
+- owner run の lock を確認してから publish する
+- active branch を `origin` へ push する
+- branch に対応する既存 PR があれば更新し、なければ draft PR を作成する
+- `shinobi:reviewing` を付与し、`shinobi:risky` 以外の状態 label を正規化する
+- start 時の mission-state comment を `phase: publish` と最新 `pr` / `lease_expires_at` へ upsert する
+- `.shinobi/state.json` を `phase: publish`、`last_result: published` に更新する
 
 ## 実装優先順位
 

--- a/docs/mvp-design.md
+++ b/docs/mvp-design.md
@@ -367,6 +367,8 @@ needs-human -> ready
 - finalize blocked: `shinobi:blocked` を付与し、`shinobi:risky` を除く他の状態 label を除去する
 - finalize needs-human: `shinobi:needs-human` を付与し、`shinobi:risky` を除く他の状態 label を除去する
 
+publish 直前に現在の Issue がすでに `shinobi:blocked` または `shinobi:needs-human` を持つ場合は、人手の停止判断を優先し、push / PR 作成前に publish を中止します。
+
 `shinobi:risky` は補助ラベルなので自動では除去しません。
 
 ## ドメインモデル

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -356,6 +356,8 @@ max_token_budget: 40000
 
 high-risk path は context で候補抽出し、execute 完了前に publish 可否を最終判定します。publish 前に確定した場合でも、human handoff に必要な差分があるなら branch を push し、原則 draft PR を作成または更新してから `shinobi:needs-human` か `shinobi:blocked` へ遷移します。この pre-publish stop で PR を作成または更新した場合も、machine-readable な mission-state comment は同じ mission の comment を upsert し、最新の `pr`, `phase`, `lease_expires_at` を反映して recovery と整合させます。差分が無いか共有価値が無い場合だけ PR を作らず停止します。publish 後に review で追加検知した場合は PR を残したまま `shinobi:needs-human` へ遷移します。
 
+publish 直前に現在の Issue がすでに `shinobi:blocked` または `shinobi:needs-human` を持つ場合は、人手の停止判断を優先し、push / PR 作成前に publish を中止します。
+
 ## Interrupted Run Recovery
 
 MVP では interrupted run からの回復を手動 cleanup 前提にしません。

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -199,7 +199,6 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
                 run_id=run_id,
                 state=store.load_state(),
                 execution_result=execution_result,
-                now=now,
             )
         except (MissionStartError, MissionPublishError, RuntimeError, ValueError) as error:
             print(f"run aborted: {error}")

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -16,9 +16,18 @@ from .issue_selector import (
     list_open_issues_with_any_label,
     select_ready_issue,
 )
-from .mission_publish import MissionPublishError, publish_mission
-from .mission_start import MissionStartError, start_mission
-from .models import State
+from .mission_publish import (
+    MissionPublishError,
+    blocking_verification_results,
+    publish_mission,
+)
+from .mission_start import (
+    MissionStartError,
+    StartedMission,
+    handoff_started_mission,
+    start_mission,
+)
+from .models import Config, ExecutionResult, State
 from .state_store import StateStore
 
 
@@ -192,6 +201,14 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
                 now=now,
             )
             execution_result = execute_verification(root, config)
+            handoff_failed_verification(
+                root=root,
+                store=store,
+                config=config,
+                run_id=run_id,
+                started_mission=started_mission,
+                execution_result=execution_result,
+            )
             published_mission = publish_mission(
                 root=root,
                 store=store,
@@ -245,6 +262,37 @@ def detect_local_mission_conflict(*, state: State, requested_issue: Optional[int
         )
 
     return None
+
+
+def handoff_failed_verification(
+    *,
+    root: Path,
+    store: StateStore,
+    config: Config,
+    run_id: str,
+    started_mission: StartedMission,
+    execution_result: ExecutionResult,
+) -> None:
+    blocking_results = blocking_verification_results(execution_result)
+    if not blocking_results:
+        return
+
+    rendered_results = ", ".join(
+        f"{command.name}: {command.status}" for command in blocking_results
+    )
+    reason = (
+        "Shinobi stopped before publish because verification failed or errored "
+        f"({rendered_results})."
+    )
+    handoff_started_mission(
+        root=root,
+        store=store,
+        config=config,
+        run_id=run_id,
+        started_mission=started_mission,
+        reason=reason,
+    )
+    raise MissionPublishError(reason)
 
 
 def main(argv: Optional[List[str]] = None) -> int:

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from .config import discover_workspace_root
+from .executor import execute_verification
 from .issue_selector import (
     ensure_open_issue,
     load_issue,
@@ -15,14 +16,10 @@ from .issue_selector import (
     list_open_issues_with_any_label,
     select_ready_issue,
 )
-from .mission_start import MissionStartError, handoff_started_mission, start_mission
+from .mission_publish import MissionPublishError, publish_mission
+from .mission_start import MissionStartError, start_mission
 from .models import State
 from .state_store import StateStore
-
-CONTEXT_PHASE_NOT_IMPLEMENTED_REASON = (
-    "Shinobi completed the start phase, but the context phase is not implemented yet. "
-    "Handing off this mission for manual follow-up."
-)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -194,15 +191,17 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
                 issue=issue,
                 now=now,
             )
-            handoff_started_mission(
+            execution_result = execute_verification(root, config)
+            published_mission = publish_mission(
                 root=root,
                 store=store,
                 config=config,
                 run_id=run_id,
-                started_mission=started_mission,
-                reason=CONTEXT_PHASE_NOT_IMPLEMENTED_REASON,
+                state=store.load_state(),
+                execution_result=execution_result,
+                now=now,
             )
-        except (MissionStartError, RuntimeError, ValueError) as error:
+        except (MissionStartError, MissionPublishError, RuntimeError, ValueError) as error:
             print(f"run aborted: {error}")
             return 1
 
@@ -213,8 +212,11 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
             print("run lock: acquired for select phase")
         print(f"selected_issue: {selected_issue}")
         print(f"started_branch: {started_mission.branch}")
-        print(f"lease_expires_at: {started_mission.lease_expires_at}")
-        print("next_phase: manual-handoff")
+        print(f"published_pr: #{published_mission.pr_number}")
+        if published_mission.pr_url:
+            print(f"published_pr_url: {published_mission.pr_url}")
+        print(f"lease_expires_at: {published_mission.lease_expires_at}")
+        print("next_phase: review")
         return 0
     finally:
         store.clear_lock(run_id)

--- a/src/shinobi/github_client.py
+++ b/src/shinobi/github_client.py
@@ -164,6 +164,13 @@ class GitHubClient:
         )
         return self.get_pull_request(str(pr_number))
 
+    def convert_pull_request_to_ready(self, pr_number: int) -> dict[str, Any]:
+        self._run_gh(
+            ["pr", "ready", str(pr_number)],
+            action=f"mark PR #{pr_number} ready for review",
+        )
+        return self.get_pull_request(str(pr_number))
+
     def get_pull_request(self, identifier: str) -> dict[str, Any]:
         payload = self._run_gh_json(
             ["pr", "view", identifier, "--json", "number,url,isDraft,headRefName,baseRefName"],

--- a/src/shinobi/github_client.py
+++ b/src/shinobi/github_client.py
@@ -157,6 +157,13 @@ class GitHubClient:
         self._run_gh(args, action=f"update PR #{pr_number}")
         return self.get_pull_request(str(pr_number))
 
+    def convert_pull_request_to_draft(self, pr_number: int) -> dict[str, Any]:
+        self._run_gh(
+            ["pr", "ready", str(pr_number), "--undo"],
+            action=f"convert PR #{pr_number} to draft",
+        )
+        return self.get_pull_request(str(pr_number))
+
     def get_pull_request(self, identifier: str) -> dict[str, Any]:
         payload = self._run_gh_json(
             ["pr", "view", identifier, "--json", "number,url,isDraft,headRefName,baseRefName"],

--- a/src/shinobi/github_client.py
+++ b/src/shinobi/github_client.py
@@ -166,6 +166,26 @@ class GitHubClient:
             raise GitHubClientError(f"failed to parse PR {identifier}: expected object payload")
         return payload
 
+    def list_pull_requests_by_head(self, head: str) -> list[dict[str, Any]]:
+        payload = self._run_gh_json(
+            [
+                "pr",
+                "list",
+                "--head",
+                head,
+                "--state",
+                "open",
+                "--json",
+                "number,url,isDraft,headRefName,baseRefName",
+            ],
+            action=f"list PRs for head {head}",
+        )
+        if not isinstance(payload, list):
+            raise GitHubClientError(
+                f"failed to parse PR list for head {head}: expected list payload"
+            )
+        return [pr for pr in payload if isinstance(pr, dict)]
+
     def get_ci_status(self, pr_number: int) -> list[dict[str, Any]]:
         payload = self._run_gh_json(
             [

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -74,21 +74,39 @@ def publish_mission(
         published_at + timedelta(minutes=config.mission_lease_minutes)
     )
 
-    sync_publish_labels(
-        client=client,
-        issue_number=issue_number,
-        config=config,
-        current_label_names=issue_label_names,
-    )
-    upsert_publish_comment(
-        client=client,
-        issue_number=issue_number,
-        branch=branch,
-        pr_number=pr_number,
-        lease_expires_at=lease_expires_at,
-        agent_identity=config.agent_identity,
-        run_id=run_id,
-    )
+    publish_label_names = issue_label_names | {config.labels["reviewing"]}
+    try:
+        sync_publish_labels(
+            client=client,
+            issue_number=issue_number,
+            config=config,
+            current_label_names=issue_label_names,
+        )
+        upsert_publish_comment(
+            client=client,
+            issue_number=issue_number,
+            branch=branch,
+            pr_number=pr_number,
+            lease_expires_at=lease_expires_at,
+            agent_identity=config.agent_identity,
+            run_id=run_id,
+        )
+    except MissionPublishError as error:
+        rollback_error = transition_publish_failure_to_needs_human(
+            client=client,
+            issue_number=issue_number,
+            pr_number=pr_number,
+            config=config,
+            reason=(
+                "Shinobi failed to complete publish phase after creating or updating "
+                f"PR #{pr_number}: {error}"
+            ),
+            known_label_names=publish_label_names,
+        )
+        message = str(error)
+        if rollback_error is not None:
+            message += f"; failed to hand off publish failure: {rollback_error}"
+        raise MissionPublishError(message) from error
 
     published_state = State(
         issue_number=issue_number,
@@ -106,10 +124,24 @@ def publish_mission(
     try:
         store.save_state(published_state)
     except OSError as error:
-        raise MissionPublishError(
+        rollback_error = transition_publish_failure_to_needs_human(
+            client=client,
+            issue_number=issue_number,
+            pr_number=pr_number,
+            config=config,
+            reason=(
+                "Shinobi failed to persist final local state during publish phase "
+                f"after updating PR #{pr_number}: {error}"
+            ),
+            known_label_names=publish_label_names,
+        )
+        message = (
             "GitHub PR, labels, and mission-state comment were updated but final "
             f"local state persistence failed for issue #{issue_number}: {error}"
-        ) from error
+        )
+        if rollback_error is not None:
+            message += f"; failed to hand off publish failure: {rollback_error}"
+        raise MissionPublishError(message) from error
 
     return PublishedMission(
         issue_number=issue_number,
@@ -298,6 +330,35 @@ def sync_publish_labels(
         raise MissionPublishError(
             f"failed to normalize publish labels for issue #{issue_number}: {error}"
         ) from error
+
+
+def transition_publish_failure_to_needs_human(
+    *,
+    client: GitHubClient,
+    issue_number: int,
+    pr_number: int,
+    config: Config,
+    reason: str,
+    known_label_names: set[str],
+) -> str | None:
+    needs_human_label = config.labels["needs_human"]
+    removable_labels = labels_to_remove_for_transition(
+        config=config,
+        current_label_names=known_label_names | {needs_human_label},
+        target_label=needs_human_label,
+    )
+
+    try:
+        client.update_issue_labels(issue_number, add=[needs_human_label])
+        if removable_labels:
+            client.update_issue_labels(issue_number, remove=removable_labels)
+        client.create_issue_comment(
+            issue_number,
+            f"{reason}\n\nPR: #{pr_number}\n",
+        )
+    except GitHubClientError as error:
+        return str(error)
+    return None
 
 
 def upsert_publish_comment(

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -479,10 +479,7 @@ def create_or_update_pull_request(
 
 
 def build_same_repo_head_selector(repo: str, branch: str) -> str:
-    owner, separator, _ = repo.partition("/")
-    if not separator or not owner:
-        return branch
-    return f"{owner}:{branch}"
+    return branch
 
 
 def render_pr_body(*, issue_number: int, execution_result: ExecutionResult) -> str:

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -60,8 +60,42 @@ def publish_mission(
         issue_label_names = load_publishable_issue_label_names(
             client=client,
             issue_number=issue_number,
-            config=config,
         )
+    except MissionPublishError as error:
+        raise MissionPublishError(
+            handoff_publish_failure(
+                client=client,
+                store=store,
+                issue_number=issue_number,
+                config=config,
+                branch=branch,
+                lease_expires_at=lease_expires_at,
+                agent_identity=config.agent_identity,
+                run_id=run_id,
+                known_label_names={config.labels["working"]},
+                error=error,
+                reason=(
+                    "Shinobi failed to complete publish phase before creating or "
+                    f"updating a PR for branch {branch}: {error}"
+                ),
+            )
+        ) from error
+
+    blocking_labels = find_blocking_publish_labels(
+        label_names=issue_label_names,
+        config=config,
+    )
+    if blocking_labels:
+        stop_publish_for_blocking_labels(
+            store=store,
+            issue_number=issue_number,
+            branch=branch,
+            agent_identity=config.agent_identity,
+            blocking_labels=blocking_labels,
+            blocked_label=config.labels["blocked"],
+        )
+
+    try:
         push_branch(root, branch)
     except MissionPublishError as error:
         raise MissionPublishError(
@@ -298,7 +332,6 @@ def load_publishable_issue_label_names(
     *,
     client: GitHubClient,
     issue_number: int,
-    config: Config,
 ) -> set[str]:
     try:
         issue = client.get_issue(issue_number)
@@ -307,20 +340,64 @@ def load_publishable_issue_label_names(
             f"failed to load issue #{issue_number} before publish: {error}"
         ) from error
 
-    label_names = get_issue_label_names(issue)
-    blocking_labels = sorted(
+    return get_issue_label_names(issue)
+
+
+def find_blocking_publish_labels(
+    *,
+    label_names: set[str],
+    config: Config,
+) -> list[str]:
+    return sorted(
         config.labels[key]
         for key in BLOCKING_PUBLISH_LABEL_KEYS
         if key in config.labels and config.labels[key] in label_names
     )
-    if blocking_labels:
-        joined = ", ".join(blocking_labels)
-        raise MissionPublishError(
-            f"publish phase cannot proceed because issue #{issue_number} "
-            f"has blocking label(s): {joined}"
-        )
 
-    return label_names
+
+def stop_publish_for_blocking_labels(
+    *,
+    store: StateStore,
+    issue_number: int,
+    branch: str,
+    agent_identity: str,
+    blocking_labels: list[str],
+    blocked_label: str,
+) -> None:
+    joined = ", ".join(blocking_labels)
+    conclusion = "blocked" if blocked_label in blocking_labels else "needs-human"
+    reason = (
+        f"publish phase cannot proceed because issue #{issue_number} "
+        f"has blocking label(s): {joined}"
+    )
+    try:
+        store.save_state(
+            State(
+                issue_number=None,
+                pr_number=None,
+                branch=None,
+                agent_identity=agent_identity,
+                run_id=None,
+                phase="idle",
+                review_loop_count=0,
+                retryable_local_only=False,
+                lease_expires_at=None,
+                last_result=conclusion,
+                last_error=reason,
+                last_mission=MissionSummary(
+                    issue_number=issue_number,
+                    pr_number=None,
+                    branch=branch,
+                    phase="publish",
+                    conclusion=conclusion,
+                ),
+            )
+        )
+    except OSError as error:
+        raise MissionPublishError(
+            f"{reason}; additionally failed to persist local stopped state: {error}"
+        ) from error
+    raise MissionPublishError(reason)
 
 
 def create_or_update_pull_request(

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -61,13 +61,34 @@ def publish_mission(
 
     push_branch(root, branch)
 
-    pr = create_or_update_pull_request(
-        client=client,
-        config=config,
-        issue_number=issue_number,
-        branch=branch,
-        execution_result=execution_result,
-    )
+    try:
+        pr = create_or_update_pull_request(
+            client=client,
+            config=config,
+            issue_number=issue_number,
+            branch=branch,
+            execution_result=execution_result,
+        )
+    except MissionPublishError as error:
+        rollback_error = transition_publish_failure_to_needs_human(
+            client=client,
+            issue_number=issue_number,
+            config=config,
+            reason=(
+                "Shinobi failed to complete publish phase after pushing branch "
+                f"{branch}: {error}"
+            ),
+            known_label_names=load_handoff_label_names(
+                client=client,
+                issue_number=issue_number,
+                fallback_label_names=issue_label_names,
+            ),
+            branch=branch,
+        )
+        message = str(error)
+        if rollback_error is not None:
+            message += f"; failed to hand off publish failure: {rollback_error}"
+        raise MissionPublishError(message) from error
     pr_number = int(pr["number"])
     pr_url = str(pr.get("url") or "") or None
     lease_expires_at = store.format_timestamp(
@@ -94,7 +115,6 @@ def publish_mission(
         rollback_error = transition_publish_failure_to_needs_human(
             client=client,
             issue_number=issue_number,
-            pr_number=pr_number,
             config=config,
             reason=(
                 "Shinobi failed to complete publish phase after creating or updating "
@@ -105,6 +125,8 @@ def publish_mission(
                 issue_number=issue_number,
                 fallback_label_names=issue_label_names,
             ),
+            pr_number=pr_number,
+            branch=branch,
         )
         message = str(error)
         if rollback_error is not None:
@@ -130,7 +152,6 @@ def publish_mission(
         rollback_error = transition_publish_failure_to_needs_human(
             client=client,
             issue_number=issue_number,
-            pr_number=pr_number,
             config=config,
             reason=(
                 "Shinobi failed to persist final local state during publish phase "
@@ -141,6 +162,8 @@ def publish_mission(
                 issue_number=issue_number,
                 fallback_label_names={config.labels["reviewing"]},
             ),
+            pr_number=pr_number,
+            branch=branch,
         )
         message = (
             "GitHub PR, labels, and mission-state comment were updated but final "
@@ -355,10 +378,11 @@ def transition_publish_failure_to_needs_human(
     *,
     client: GitHubClient,
     issue_number: int,
-    pr_number: int,
     config: Config,
     reason: str,
     known_label_names: set[str],
+    pr_number: int | None = None,
+    branch: str | None = None,
 ) -> str | None:
     needs_human_label = config.labels["needs_human"]
     removable_labels = labels_to_remove_for_transition(
@@ -382,12 +406,30 @@ def transition_publish_failure_to_needs_human(
     try:
         client.create_issue_comment(
             issue_number,
-            f"{reason}\n\nPR: #{pr_number}\n",
+            render_publish_failure_comment(
+                reason=reason,
+                pr_number=pr_number,
+                branch=branch,
+            ),
         )
     except GitHubClientError as error:
         errors.append(str(error))
 
     return "; ".join(errors) or None
+
+
+def render_publish_failure_comment(
+    *,
+    reason: str,
+    pr_number: int | None,
+    branch: str | None,
+) -> str:
+    lines = [reason, ""]
+    if branch:
+        lines.append(f"Branch: `{branch}`")
+    if pr_number is not None:
+        lines.append(f"PR: #{pr_number}")
+    return "\n".join(lines) + "\n"
 
 
 def upsert_publish_comment(

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -229,8 +229,13 @@ def create_or_update_pull_request(
     title = f"#{issue_number} Publish mission changes"
     body = render_pr_body(issue_number=issue_number, execution_result=execution_result)
     try:
-        existing_pr = client.get_pull_request(branch)
-    except GitHubClientError:
+        existing_prs = client.list_pull_requests_by_head(branch)
+    except GitHubClientError as error:
+        raise MissionPublishError(
+            f"failed to look up existing PR for issue #{issue_number}: {error}"
+        ) from error
+
+    if not existing_prs:
         try:
             return client.create_pull_request(
                 title=title,
@@ -244,6 +249,7 @@ def create_or_update_pull_request(
                 f"failed to create PR for issue #{issue_number}: {error}"
             ) from error
 
+    existing_pr = existing_prs[0]
     try:
         return client.update_pull_request(
             int(existing_pr["number"]),

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -39,6 +39,7 @@ def publish_mission(
 ) -> PublishedMission:
     published_at = now or datetime.now(timezone.utc)
     issue_number, branch = require_publishable_state(state)
+    require_publishable_execution_result(execution_result)
     store.require_lock_owner(run_id, config.agent_identity)
     store.refresh_lock_heartbeat(
         run_id=run_id,
@@ -115,6 +116,24 @@ def require_publishable_state(state: State) -> tuple[int, str]:
     if state.retryable_local_only:
         raise MissionPublishError("publish phase cannot run on retryable local-only state")
     return state.issue_number, state.branch
+
+
+def require_publishable_execution_result(execution_result: ExecutionResult) -> None:
+    blocking_results = [
+        command
+        for command in execution_result.commands
+        if command.status in {"failed", "error"}
+    ]
+    if not blocking_results:
+        return
+
+    rendered_results = ", ".join(
+        f"{command.name}: {command.status}" for command in blocking_results
+    )
+    raise MissionPublishError(
+        "publish phase requires verification commands without failed/error results "
+        f"({rendered_results})"
+    )
 
 
 def push_branch(root: Path, branch: str) -> None:

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from .github_client import GitHubClient, GitHubClientError
 from .mission_start import get_issue_label_names, labels_to_remove_for_transition
-from .models import Config, ExecutionResult, State
+from .models import Config, ExecutionResult, State, VerificationCommandResult
 from .state_store import StateStore
 
 MISSION_STATE_MARKER = "<!-- shinobi:mission-state"
@@ -137,11 +137,7 @@ def require_publishable_state(
 
 
 def require_publishable_execution_result(execution_result: ExecutionResult) -> None:
-    blocking_results = [
-        command
-        for command in execution_result.commands
-        if command.status in {"failed", "error"}
-    ]
+    blocking_results = blocking_verification_results(execution_result)
     if not blocking_results:
         return
 
@@ -152,6 +148,16 @@ def require_publishable_execution_result(execution_result: ExecutionResult) -> N
         "publish phase requires verification commands without failed/error results "
         f"({rendered_results})"
     )
+
+
+def blocking_verification_results(
+    execution_result: ExecutionResult,
+) -> list[VerificationCommandResult]:
+    return [
+        command
+        for command in execution_result.commands
+        if command.status in {"failed", "error"}
+    ]
 
 
 def push_branch(root: Path, branch: str) -> None:

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -12,6 +12,7 @@ from .models import Config, ExecutionResult, State, VerificationCommandResult
 from .state_store import StateStore
 
 MISSION_STATE_MARKER = "<!-- shinobi:mission-state"
+BLOCKING_PUBLISH_LABEL_KEYS = ("blocked", "needs_human")
 
 
 class MissionPublishError(RuntimeError):
@@ -51,9 +52,15 @@ def publish_mission(
         now=published_at,
     )
 
+    client = GitHubClient(root, repo=config.repo)
+    issue_label_names = load_publishable_issue_label_names(
+        client=client,
+        issue_number=issue_number,
+        config=config,
+    )
+
     push_branch(root, branch)
 
-    client = GitHubClient(root, repo=config.repo)
     pr = create_or_update_pull_request(
         client=client,
         config=config,
@@ -67,7 +74,12 @@ def publish_mission(
         published_at + timedelta(minutes=config.mission_lease_minutes)
     )
 
-    sync_publish_labels(client=client, issue_number=issue_number, config=config)
+    sync_publish_labels(
+        client=client,
+        issue_number=issue_number,
+        config=config,
+        current_label_names=issue_label_names,
+    )
     upsert_publish_comment(
         client=client,
         issue_number=issue_number,
@@ -177,6 +189,35 @@ def push_branch(root: Path, branch: str) -> None:
         raise MissionPublishError(f"failed to push branch {branch}: {message}")
 
 
+def load_publishable_issue_label_names(
+    *,
+    client: GitHubClient,
+    issue_number: int,
+    config: Config,
+) -> set[str]:
+    try:
+        issue = client.get_issue(issue_number)
+    except GitHubClientError as error:
+        raise MissionPublishError(
+            f"failed to load issue #{issue_number} before publish: {error}"
+        ) from error
+
+    label_names = get_issue_label_names(issue)
+    blocking_labels = sorted(
+        config.labels[key]
+        for key in BLOCKING_PUBLISH_LABEL_KEYS
+        if key in config.labels and config.labels[key] in label_names
+    )
+    if blocking_labels:
+        joined = ", ".join(blocking_labels)
+        raise MissionPublishError(
+            f"publish phase cannot proceed because issue #{issue_number} "
+            f"has blocking label(s): {joined}"
+        )
+
+    return label_names
+
+
 def create_or_update_pull_request(
     *,
     client: GitHubClient,
@@ -235,11 +276,10 @@ def sync_publish_labels(
     client: GitHubClient,
     issue_number: int,
     config: Config,
+    current_label_names: set[str],
 ) -> None:
     reviewing_label = config.labels["reviewing"]
     try:
-        issue = client.get_issue(issue_number)
-        current_label_names = get_issue_label_names(issue)
         removable_labels = labels_to_remove_for_transition(
             config=config,
             current_label_names=current_label_names | {reviewing_label},

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -74,7 +74,6 @@ def publish_mission(
         published_at + timedelta(minutes=config.mission_lease_minutes)
     )
 
-    publish_label_names = issue_label_names | {config.labels["reviewing"]}
     try:
         sync_publish_labels(
             client=client,
@@ -101,7 +100,11 @@ def publish_mission(
                 "Shinobi failed to complete publish phase after creating or updating "
                 f"PR #{pr_number}: {error}"
             ),
-            known_label_names=publish_label_names,
+            known_label_names=load_handoff_label_names(
+                client=client,
+                issue_number=issue_number,
+                fallback_label_names=issue_label_names,
+            ),
         )
         message = str(error)
         if rollback_error is not None:
@@ -133,7 +136,11 @@ def publish_mission(
                 "Shinobi failed to persist final local state during publish phase "
                 f"after updating PR #{pr_number}: {error}"
             ),
-            known_label_names=publish_label_names,
+            known_label_names=load_handoff_label_names(
+                client=client,
+                issue_number=issue_number,
+                fallback_label_names={config.labels["reviewing"]},
+            ),
         )
         message = (
             "GitHub PR, labels, and mission-state comment were updated but final "
@@ -332,6 +339,18 @@ def sync_publish_labels(
         ) from error
 
 
+def load_handoff_label_names(
+    *,
+    client: GitHubClient,
+    issue_number: int,
+    fallback_label_names: set[str],
+) -> set[str]:
+    try:
+        return get_issue_label_names(client.get_issue(issue_number))
+    except GitHubClientError:
+        return set(fallback_label_names)
+
+
 def transition_publish_failure_to_needs_human(
     *,
     client: GitHubClient,
@@ -348,17 +367,27 @@ def transition_publish_failure_to_needs_human(
         target_label=needs_human_label,
     )
 
+    errors: list[str] = []
     try:
         client.update_issue_labels(issue_number, add=[needs_human_label])
-        if removable_labels:
+    except GitHubClientError as error:
+        errors.append(str(error))
+
+    if removable_labels:
+        try:
             client.update_issue_labels(issue_number, remove=removable_labels)
+        except GitHubClientError as error:
+            errors.append(str(error))
+
+    try:
         client.create_issue_comment(
             issue_number,
             f"{reason}\n\nPR: #{pr_number}\n",
         )
     except GitHubClientError as error:
-        return str(error)
-    return None
+        errors.append(str(error))
+
+    return "; ".join(errors) or None
 
 
 def upsert_publish_comment(

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -313,7 +313,7 @@ def create_or_update_pull_request(
 
     existing_pr = existing_prs[0]
     try:
-        return client.update_pull_request(
+        updated_pr = client.update_pull_request(
             int(existing_pr["number"]),
             title=title,
             body=body,
@@ -323,6 +323,17 @@ def create_or_update_pull_request(
         raise MissionPublishError(
             f"failed to update PR #{existing_pr.get('number')} for issue #{issue_number}: {error}"
         ) from error
+
+    if config.use_draft_pr and not bool(updated_pr.get("isDraft")):
+        pr_number = int(updated_pr["number"])
+        try:
+            return client.convert_pull_request_to_draft(pr_number)
+        except GitHubClientError as error:
+            raise MissionPublishError(
+                f"failed to convert PR #{pr_number} to draft for issue #{issue_number}: {error}"
+            ) from error
+
+    return updated_pr
 
 
 def render_pr_body(*, issue_number: int, execution_result: ExecutionResult) -> str:

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -341,7 +341,19 @@ def create_or_update_pull_request(
             f"failed to look up existing PR for issue #{issue_number}: {error}"
         ) from error
 
-    if not existing_prs:
+    matching_prs = [
+        pr
+        for pr in existing_prs
+        if str(pr.get("headRefName") or "") == branch
+        and str(pr.get("baseRefName") or "") == config.main_branch
+    ]
+    if len(matching_prs) > 1:
+        raise MissionPublishError(
+            "failed to choose existing PR for "
+            f"issue #{issue_number}: multiple open PRs match {branch} -> {config.main_branch}"
+        )
+
+    if not matching_prs:
         try:
             return client.create_pull_request(
                 title=title,
@@ -355,7 +367,7 @@ def create_or_update_pull_request(
                 f"failed to create PR for issue #{issue_number}: {error}"
             ) from error
 
-    existing_pr = existing_prs[0]
+    existing_pr = matching_prs[0]
     try:
         updated_pr = client.update_pull_request(
             int(existing_pr["number"]),

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -56,13 +56,32 @@ def publish_mission(
     )
 
     client = GitHubClient(root, repo=config.repo)
-    issue_label_names = load_publishable_issue_label_names(
-        client=client,
-        issue_number=issue_number,
-        config=config,
-    )
-
-    push_branch(root, branch)
+    try:
+        issue_label_names = load_publishable_issue_label_names(
+            client=client,
+            issue_number=issue_number,
+            config=config,
+        )
+        push_branch(root, branch)
+    except MissionPublishError as error:
+        raise MissionPublishError(
+            handoff_publish_failure(
+                client=client,
+                store=store,
+                issue_number=issue_number,
+                config=config,
+                branch=branch,
+                lease_expires_at=lease_expires_at,
+                agent_identity=config.agent_identity,
+                run_id=run_id,
+                known_label_names={config.labels["working"]},
+                error=error,
+                reason=(
+                    "Shinobi failed to complete publish phase before creating or "
+                    f"updating a PR for branch {branch}: {error}"
+                ),
+            )
+        ) from error
 
     try:
         pr = create_or_update_pull_request(
@@ -73,39 +92,28 @@ def publish_mission(
             execution_result=execution_result,
         )
     except MissionPublishError as error:
-        rollback_error = transition_publish_failure_to_needs_human(
-            client=client,
-            issue_number=issue_number,
-            config=config,
-            reason=(
-                "Shinobi failed to complete publish phase after pushing branch "
-                f"{branch}: {error}"
-            ),
-            known_label_names=load_handoff_label_names(
+        raise MissionPublishError(
+            handoff_publish_failure(
                 client=client,
-                issue_number=issue_number,
-                fallback_label_names=issue_label_names,
-            ),
-            lease_expires_at=lease_expires_at,
-            agent_identity=config.agent_identity,
-            run_id=run_id,
-            branch=branch,
-        )
-        state_error = None
-        if rollback_error is None:
-            state_error = save_publish_handoff_state(
                 store=store,
                 issue_number=issue_number,
+                config=config,
                 branch=branch,
+                lease_expires_at=lease_expires_at,
                 agent_identity=config.agent_identity,
-                reason=str(error),
+                run_id=run_id,
+                known_label_names=load_handoff_label_names(
+                    client=client,
+                    issue_number=issue_number,
+                    fallback_label_names=issue_label_names,
+                ),
+                error=error,
+                reason=(
+                    "Shinobi failed to complete publish phase after pushing branch "
+                    f"{branch}: {error}"
+                ),
             )
-        message = str(error)
-        if rollback_error is not None:
-            message += f"; failed to hand off publish failure: {rollback_error}"
-        elif state_error is not None:
-            message += f"; failed to persist local publish handoff state: {state_error}"
-        raise MissionPublishError(message) from error
+        ) from error
     pr_number = int(pr["number"])
     pr_url = str(pr.get("url") or "") or None
 
@@ -126,41 +134,29 @@ def publish_mission(
             run_id=run_id,
         )
     except MissionPublishError as error:
-        rollback_error = transition_publish_failure_to_needs_human(
-            client=client,
-            issue_number=issue_number,
-            config=config,
-            reason=(
-                "Shinobi failed to complete publish phase after creating or updating "
-                f"PR #{pr_number}: {error}"
-            ),
-            known_label_names=load_handoff_label_names(
+        raise MissionPublishError(
+            handoff_publish_failure(
                 client=client,
-                issue_number=issue_number,
-                fallback_label_names=issue_label_names,
-            ),
-            lease_expires_at=lease_expires_at,
-            agent_identity=config.agent_identity,
-            run_id=run_id,
-            pr_number=pr_number,
-            branch=branch,
-        )
-        state_error = None
-        if rollback_error is None:
-            state_error = save_publish_handoff_state(
                 store=store,
                 issue_number=issue_number,
-                pr_number=pr_number,
+                config=config,
                 branch=branch,
+                lease_expires_at=lease_expires_at,
                 agent_identity=config.agent_identity,
-                reason=str(error),
+                run_id=run_id,
+                known_label_names=load_handoff_label_names(
+                    client=client,
+                    issue_number=issue_number,
+                    fallback_label_names=issue_label_names,
+                ),
+                error=error,
+                reason=(
+                    "Shinobi failed to complete publish phase after creating or updating "
+                    f"PR #{pr_number}: {error}"
+                ),
+                pr_number=pr_number,
             )
-        message = str(error)
-        if rollback_error is not None:
-            message += f"; failed to hand off publish failure: {rollback_error}"
-        elif state_error is not None:
-            message += f"; failed to persist local publish handoff state: {state_error}"
-        raise MissionPublishError(message) from error
+        ) from error
 
     published_state = State(
         issue_number=issue_number,
@@ -447,6 +443,52 @@ def load_handoff_label_names(
         return get_issue_label_names(client.get_issue(issue_number))
     except GitHubClientError:
         return set(fallback_label_names)
+
+
+def handoff_publish_failure(
+    *,
+    client: GitHubClient,
+    store: StateStore,
+    issue_number: int,
+    config: Config,
+    branch: str,
+    lease_expires_at: str,
+    agent_identity: str,
+    run_id: str,
+    known_label_names: set[str],
+    error: MissionPublishError,
+    reason: str,
+    pr_number: int | None = None,
+) -> str:
+    rollback_error = transition_publish_failure_to_needs_human(
+        client=client,
+        issue_number=issue_number,
+        config=config,
+        reason=reason,
+        known_label_names=known_label_names,
+        lease_expires_at=lease_expires_at,
+        agent_identity=agent_identity,
+        run_id=run_id,
+        pr_number=pr_number,
+        branch=branch,
+    )
+    state_error = None
+    if rollback_error is None:
+        state_error = save_publish_handoff_state(
+            store=store,
+            issue_number=issue_number,
+            pr_number=pr_number,
+            branch=branch,
+            agent_identity=agent_identity,
+            reason=str(error),
+        )
+
+    message = str(error)
+    if rollback_error is not None:
+        message += f"; failed to hand off publish failure: {rollback_error}"
+    elif state_error is not None:
+        message += f"; failed to persist local publish handoff state: {state_error}"
+    return message
 
 
 def save_publish_handoff_state(

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -40,6 +40,11 @@ def publish_mission(
     published_at = now or datetime.now(timezone.utc)
     issue_number, branch = require_publishable_state(state)
     store.require_lock_owner(run_id, config.agent_identity)
+    store.refresh_lock_heartbeat(
+        run_id=run_id,
+        agent_identity=config.agent_identity,
+        now=published_at,
+    )
 
     push_branch(root, branch)
 

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from .github_client import GitHubClient, GitHubClientError
+from .mission_start import get_issue_label_names, labels_to_remove_for_transition
+from .models import Config, ExecutionResult, State
+from .state_store import StateStore
+
+MISSION_STATE_MARKER = "<!-- shinobi:mission-state"
+
+
+class MissionPublishError(RuntimeError):
+    """Raised when the publish phase cannot complete safely."""
+
+
+@dataclass(frozen=True)
+class PublishedMission:
+    issue_number: int
+    pr_number: int
+    branch: str
+    lease_expires_at: str
+    pr_url: str | None = None
+
+
+def publish_mission(
+    *,
+    root: Path,
+    store: StateStore,
+    config: Config,
+    run_id: str,
+    state: State,
+    execution_result: ExecutionResult,
+    now: datetime | None = None,
+) -> PublishedMission:
+    published_at = now or datetime.now(timezone.utc)
+    issue_number, branch = require_publishable_state(state)
+    store.require_lock_owner(run_id, config.agent_identity)
+
+    push_branch(root, branch)
+
+    client = GitHubClient(root, repo=config.repo)
+    pr = create_or_update_pull_request(
+        client=client,
+        config=config,
+        issue_number=issue_number,
+        branch=branch,
+        execution_result=execution_result,
+    )
+    pr_number = int(pr["number"])
+    pr_url = str(pr.get("url") or "") or None
+    lease_expires_at = store.format_timestamp(
+        published_at + timedelta(minutes=config.mission_lease_minutes)
+    )
+
+    sync_publish_labels(client=client, issue_number=issue_number, config=config)
+    upsert_publish_comment(
+        client=client,
+        issue_number=issue_number,
+        branch=branch,
+        pr_number=pr_number,
+        lease_expires_at=lease_expires_at,
+        agent_identity=config.agent_identity,
+        run_id=run_id,
+    )
+
+    published_state = State(
+        issue_number=issue_number,
+        pr_number=pr_number,
+        branch=branch,
+        agent_identity=config.agent_identity,
+        run_id=run_id,
+        phase="publish",
+        review_loop_count=state.review_loop_count,
+        retryable_local_only=False,
+        lease_expires_at=lease_expires_at,
+        last_result="published",
+        last_error=None,
+    )
+    try:
+        store.save_state(published_state)
+    except OSError as error:
+        raise MissionPublishError(
+            "GitHub PR, labels, and mission-state comment were updated but final "
+            f"local state persistence failed for issue #{issue_number}: {error}"
+        ) from error
+
+    return PublishedMission(
+        issue_number=issue_number,
+        pr_number=pr_number,
+        branch=branch,
+        lease_expires_at=lease_expires_at,
+        pr_url=pr_url,
+    )
+
+
+def require_publishable_state(state: State) -> tuple[int, str]:
+    if state.phase != "start":
+        raise MissionPublishError(
+            f"publish phase requires local state phase start, got {state.phase}"
+        )
+    if state.issue_number is None:
+        raise MissionPublishError("publish phase requires issue_number in local state")
+    if not state.branch:
+        raise MissionPublishError("publish phase requires branch in local state")
+    if state.retryable_local_only:
+        raise MissionPublishError("publish phase cannot run on retryable local-only state")
+    return state.issue_number, state.branch
+
+
+def push_branch(root: Path, branch: str) -> None:
+    try:
+        result = subprocess.run(
+            ["git", "push", "-u", "origin", branch],
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as error:
+        raise MissionPublishError(f"failed to push branch {branch}: {error}") from error
+
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or f"git exited with {result.returncode}"
+        raise MissionPublishError(f"failed to push branch {branch}: {message}")
+
+
+def create_or_update_pull_request(
+    *,
+    client: GitHubClient,
+    config: Config,
+    issue_number: int,
+    branch: str,
+    execution_result: ExecutionResult,
+) -> dict[str, Any]:
+    title = f"#{issue_number} Publish mission changes"
+    body = render_pr_body(issue_number=issue_number, execution_result=execution_result)
+    try:
+        existing_pr = client.get_pull_request(branch)
+    except GitHubClientError:
+        try:
+            return client.create_pull_request(
+                title=title,
+                body=body,
+                base=config.main_branch,
+                head=branch,
+                draft=config.use_draft_pr,
+            )
+        except GitHubClientError as error:
+            raise MissionPublishError(
+                f"failed to create PR for issue #{issue_number}: {error}"
+            ) from error
+
+    try:
+        return client.update_pull_request(
+            int(existing_pr["number"]),
+            title=title,
+            body=body,
+            base=config.main_branch,
+        )
+    except GitHubClientError as error:
+        raise MissionPublishError(
+            f"failed to update PR #{existing_pr.get('number')} for issue #{issue_number}: {error}"
+        ) from error
+
+
+def render_pr_body(*, issue_number: int, execution_result: ExecutionResult) -> str:
+    lines = [
+        "## Summary",
+        f"- Refs #{issue_number}",
+        f"- {execution_result.change_summary}",
+        "",
+        "## Verification",
+    ]
+    for command in execution_result.commands:
+        rendered_command = " ".join(command.command) if command.command else "not configured"
+        lines.append(f"- {command.name}: {command.status} (`{rendered_command}`)")
+    return "\n".join(lines) + "\n"
+
+
+def sync_publish_labels(
+    *,
+    client: GitHubClient,
+    issue_number: int,
+    config: Config,
+) -> None:
+    reviewing_label = config.labels["reviewing"]
+    try:
+        issue = client.get_issue(issue_number)
+        current_label_names = get_issue_label_names(issue)
+        removable_labels = labels_to_remove_for_transition(
+            config=config,
+            current_label_names=current_label_names | {reviewing_label},
+            target_label=reviewing_label,
+        )
+        client.update_issue_labels(issue_number, add=[reviewing_label])
+        if removable_labels:
+            client.update_issue_labels(issue_number, remove=removable_labels)
+    except GitHubClientError as error:
+        raise MissionPublishError(
+            f"failed to normalize publish labels for issue #{issue_number}: {error}"
+        ) from error
+
+
+def upsert_publish_comment(
+    *,
+    client: GitHubClient,
+    issue_number: int,
+    branch: str,
+    pr_number: int,
+    lease_expires_at: str,
+    agent_identity: str,
+    run_id: str,
+) -> None:
+    body = render_publish_comment(
+        issue_number=issue_number,
+        branch=branch,
+        pr_number=pr_number,
+        lease_expires_at=lease_expires_at,
+        agent_identity=agent_identity,
+        run_id=run_id,
+    )
+    try:
+        comment = find_mission_state_comment(
+            client.list_issue_comments(issue_number),
+            issue_number=issue_number,
+            branch=branch,
+        )
+        if comment is None:
+            client.create_issue_comment(issue_number, body)
+            return
+        client.update_issue_comment(int(comment["id"]), body)
+    except (GitHubClientError, KeyError, TypeError, ValueError) as error:
+        raise MissionPublishError(
+            f"failed to upsert mission-state comment for issue #{issue_number}: {error}"
+        ) from error
+
+
+def find_mission_state_comment(
+    comments: list[dict[str, Any]],
+    *,
+    issue_number: int,
+    branch: str,
+) -> dict[str, Any] | None:
+    for comment in comments:
+        marker_fields = parse_mission_state_fields(str(comment.get("body") or ""))
+        if marker_fields.get("issue") == str(issue_number) and marker_fields.get("branch") == branch:
+            return comment
+    return None
+
+
+def parse_mission_state_fields(body: str) -> dict[str, str]:
+    if MISSION_STATE_MARKER not in body:
+        return {}
+
+    fields: dict[str, str] = {}
+    in_marker = False
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped == MISSION_STATE_MARKER:
+            in_marker = True
+            continue
+        if not in_marker:
+            continue
+        if stripped == "-->":
+            break
+        key, separator, value = stripped.partition(":")
+        if separator:
+            fields[key.strip()] = value.strip()
+    return fields
+
+
+def render_publish_comment(
+    *,
+    issue_number: int,
+    branch: str,
+    pr_number: int,
+    lease_expires_at: str,
+    agent_identity: str,
+    run_id: str,
+) -> str:
+    return (
+        "<!-- shinobi:mission-state\n"
+        f"issue: {issue_number}\n"
+        f"branch: {branch}\n"
+        "phase: publish\n"
+        f"pr: {pr_number}\n"
+        f"lease_expires_at: {lease_expires_at}\n"
+        f"agent_identity: {agent_identity}\n"
+        f"run_id: {run_id}\n"
+        "-->\n"
+        "Shinobi Publish\n\n"
+        f"任務 #{issue_number} の draft PR を公開しました。\n"
+        f"- pr: #{pr_number}\n"
+    )

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from .github_client import GitHubClient, GitHubClientError
 from .mission_start import get_issue_label_names, labels_to_remove_for_transition
-from .models import Config, ExecutionResult, State, VerificationCommandResult
+from .models import Config, ExecutionResult, MissionSummary, State, VerificationCommandResult
 from .state_store import StateStore
 
 MISSION_STATE_MARKER = "<!-- shinobi:mission-state"
@@ -85,9 +85,20 @@ def publish_mission(
             ),
             branch=branch,
         )
+        state_error = None
+        if rollback_error is None:
+            state_error = save_publish_handoff_state(
+                store=store,
+                issue_number=issue_number,
+                branch=branch,
+                agent_identity=config.agent_identity,
+                reason=str(error),
+            )
         message = str(error)
         if rollback_error is not None:
             message += f"; failed to hand off publish failure: {rollback_error}"
+        elif state_error is not None:
+            message += f"; failed to persist local publish handoff state: {state_error}"
         raise MissionPublishError(message) from error
     pr_number = int(pr["number"])
     pr_url = str(pr.get("url") or "") or None
@@ -128,9 +139,21 @@ def publish_mission(
             pr_number=pr_number,
             branch=branch,
         )
+        state_error = None
+        if rollback_error is None:
+            state_error = save_publish_handoff_state(
+                store=store,
+                issue_number=issue_number,
+                pr_number=pr_number,
+                branch=branch,
+                agent_identity=config.agent_identity,
+                reason=str(error),
+            )
         message = str(error)
         if rollback_error is not None:
             message += f"; failed to hand off publish failure: {rollback_error}"
+        elif state_error is not None:
+            message += f"; failed to persist local publish handoff state: {state_error}"
         raise MissionPublishError(message) from error
 
     published_state = State(
@@ -165,12 +188,27 @@ def publish_mission(
             pr_number=pr_number,
             branch=branch,
         )
+        state_error = None
+        if rollback_error is None:
+            state_error = save_publish_handoff_state(
+                store=store,
+                issue_number=issue_number,
+                pr_number=pr_number,
+                branch=branch,
+                agent_identity=config.agent_identity,
+                reason=(
+                    "GitHub PR, labels, and mission-state comment were updated but final "
+                    f"local state persistence failed for issue #{issue_number}: {error}"
+                ),
+            )
         message = (
             "GitHub PR, labels, and mission-state comment were updated but final "
             f"local state persistence failed for issue #{issue_number}: {error}"
         )
         if rollback_error is not None:
             message += f"; failed to hand off publish failure: {rollback_error}"
+        elif state_error is not None:
+            message += f"; failed to persist local publish handoff state: {state_error}"
         raise MissionPublishError(message) from error
 
     return PublishedMission(
@@ -383,6 +421,43 @@ def load_handoff_label_names(
         return get_issue_label_names(client.get_issue(issue_number))
     except GitHubClientError:
         return set(fallback_label_names)
+
+
+def save_publish_handoff_state(
+    *,
+    store: StateStore,
+    issue_number: int,
+    branch: str,
+    agent_identity: str,
+    reason: str,
+    pr_number: int | None = None,
+) -> str | None:
+    try:
+        store.save_state(
+            State(
+                issue_number=None,
+                pr_number=None,
+                branch=None,
+                agent_identity=agent_identity,
+                run_id=None,
+                phase="idle",
+                review_loop_count=0,
+                retryable_local_only=False,
+                lease_expires_at=None,
+                last_result="needs-human",
+                last_error=reason,
+                last_mission=MissionSummary(
+                    issue_number=issue_number,
+                    pr_number=pr_number,
+                    branch=branch,
+                    phase="publish",
+                    conclusion="needs-human",
+                ),
+            )
+        )
+    except OSError as error:
+        return str(error)
+    return None
 
 
 def transition_publish_failure_to_needs_human(

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -337,8 +337,9 @@ def create_or_update_pull_request(
 ) -> dict[str, Any]:
     title = f"#{issue_number} Publish mission changes"
     body = render_pr_body(issue_number=issue_number, execution_result=execution_result)
+    head_selector = build_same_repo_head_selector(config.repo, branch)
     try:
-        existing_prs = client.list_pull_requests_by_head(branch)
+        existing_prs = client.list_pull_requests_by_head(head_selector)
     except GitHubClientError as error:
         raise MissionPublishError(
             f"failed to look up existing PR for issue #{issue_number}: {error}"
@@ -381,6 +382,13 @@ def create_or_update_pull_request(
             ) from error
 
     return updated_pr
+
+
+def build_same_repo_head_selector(repo: str, branch: str) -> str:
+    owner, separator, _ = repo.partition("/")
+    if not separator or not owner:
+        return branch
+    return f"{owner}:{branch}"
 
 
 def render_pr_body(*, issue_number: int, execution_result: ExecutionResult) -> str:

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -372,13 +372,22 @@ def create_or_update_pull_request(
             f"failed to update PR #{existing_pr.get('number')} for issue #{issue_number}: {error}"
         ) from error
 
-    if config.use_draft_pr and not bool(updated_pr.get("isDraft")):
-        pr_number = int(updated_pr["number"])
+    is_draft = bool(updated_pr.get("isDraft"))
+    pr_number = int(updated_pr["number"])
+    if config.use_draft_pr and not is_draft:
         try:
             return client.convert_pull_request_to_draft(pr_number)
         except GitHubClientError as error:
             raise MissionPublishError(
                 f"failed to convert PR #{pr_number} to draft for issue #{issue_number}: {error}"
+            ) from error
+    if not config.use_draft_pr and is_draft:
+        try:
+            return client.convert_pull_request_to_ready(pr_number)
+        except GitHubClientError as error:
+            raise MissionPublishError(
+                "failed to mark PR "
+                f"#{pr_number} ready for review for issue #{issue_number}: {error}"
             ) from error
 
     return updated_pr
@@ -674,7 +683,7 @@ def render_publish_comment(
         f"run_id: {run_id}\n"
         "-->\n"
         "Shinobi Publish\n\n"
-        f"任務 #{issue_number} の draft PR を公開しました。\n"
+        f"任務 #{issue_number} の PR を公開しました。\n"
         f"- pr: #{pr_number}\n"
     )
 

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -38,7 +38,11 @@ def publish_mission(
     now: datetime | None = None,
 ) -> PublishedMission:
     published_at = now or datetime.now(timezone.utc)
-    issue_number, branch = require_publishable_state(state)
+    issue_number, branch = require_publishable_state(
+        state,
+        run_id=run_id,
+        agent_identity=config.agent_identity,
+    )
     require_publishable_execution_result(execution_result)
     store.require_lock_owner(run_id, config.agent_identity)
     store.refresh_lock_heartbeat(
@@ -104,10 +108,24 @@ def publish_mission(
     )
 
 
-def require_publishable_state(state: State) -> tuple[int, str]:
+def require_publishable_state(
+    state: State,
+    *,
+    run_id: str,
+    agent_identity: str,
+) -> tuple[int, str]:
     if state.phase != "start":
         raise MissionPublishError(
             f"publish phase requires local state phase start, got {state.phase}"
+        )
+    if state.run_id != run_id:
+        raise MissionPublishError(
+            f"publish phase requires local state run_id {run_id}, got {state.run_id}"
+        )
+    if state.agent_identity != agent_identity:
+        raise MissionPublishError(
+            "publish phase requires local state agent_identity "
+            f"{agent_identity}, got {state.agent_identity}"
         )
     if state.issue_number is None:
         raise MissionPublishError("publish phase requires issue_number in local state")

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -39,6 +39,9 @@ def publish_mission(
     now: datetime | None = None,
 ) -> PublishedMission:
     published_at = now or datetime.now(timezone.utc)
+    lease_expires_at = store.format_timestamp(
+        published_at + timedelta(minutes=config.mission_lease_minutes)
+    )
     issue_number, branch = require_publishable_state(
         state,
         run_id=run_id,
@@ -83,6 +86,9 @@ def publish_mission(
                 issue_number=issue_number,
                 fallback_label_names=issue_label_names,
             ),
+            lease_expires_at=lease_expires_at,
+            agent_identity=config.agent_identity,
+            run_id=run_id,
             branch=branch,
         )
         state_error = None
@@ -102,9 +108,6 @@ def publish_mission(
         raise MissionPublishError(message) from error
     pr_number = int(pr["number"])
     pr_url = str(pr.get("url") or "") or None
-    lease_expires_at = store.format_timestamp(
-        published_at + timedelta(minutes=config.mission_lease_minutes)
-    )
 
     try:
         sync_publish_labels(
@@ -136,6 +139,9 @@ def publish_mission(
                 issue_number=issue_number,
                 fallback_label_names=issue_label_names,
             ),
+            lease_expires_at=lease_expires_at,
+            agent_identity=config.agent_identity,
+            run_id=run_id,
             pr_number=pr_number,
             branch=branch,
         )
@@ -185,6 +191,9 @@ def publish_mission(
                 issue_number=issue_number,
                 fallback_label_names={config.labels["reviewing"]},
             ),
+            lease_expires_at=lease_expires_at,
+            agent_identity=config.agent_identity,
+            run_id=run_id,
             pr_number=pr_number,
             branch=branch,
         )
@@ -467,6 +476,9 @@ def transition_publish_failure_to_needs_human(
     config: Config,
     reason: str,
     known_label_names: set[str],
+    lease_expires_at: str,
+    agent_identity: str,
+    run_id: str,
     pr_number: int | None = None,
     branch: str | None = None,
 ) -> str | None:
@@ -490,15 +502,27 @@ def transition_publish_failure_to_needs_human(
             errors.append(str(error))
 
     try:
-        client.create_issue_comment(
-            issue_number,
-            render_publish_failure_comment(
-                reason=reason,
-                pr_number=pr_number,
+        if pr_number is not None and branch:
+            upsert_publish_failure_comment(
+                client=client,
+                issue_number=issue_number,
                 branch=branch,
-            ),
-        )
-    except GitHubClientError as error:
+                pr_number=pr_number,
+                lease_expires_at=lease_expires_at,
+                agent_identity=agent_identity,
+                run_id=run_id,
+                reason=reason,
+            )
+        else:
+            client.create_issue_comment(
+                issue_number,
+                render_publish_failure_comment(
+                    reason=reason,
+                    pr_number=pr_number,
+                    branch=branch,
+                ),
+            )
+    except (GitHubClientError, MissionPublishError) as error:
         errors.append(str(error))
 
     return "; ".join(errors) or None
@@ -549,6 +573,42 @@ def upsert_publish_comment(
     except (GitHubClientError, KeyError, TypeError, ValueError) as error:
         raise MissionPublishError(
             f"failed to upsert mission-state comment for issue #{issue_number}: {error}"
+        ) from error
+
+
+def upsert_publish_failure_comment(
+    *,
+    client: GitHubClient,
+    issue_number: int,
+    branch: str,
+    pr_number: int,
+    lease_expires_at: str,
+    agent_identity: str,
+    run_id: str,
+    reason: str,
+) -> None:
+    body = render_publish_failure_state_comment(
+        issue_number=issue_number,
+        branch=branch,
+        pr_number=pr_number,
+        lease_expires_at=lease_expires_at,
+        agent_identity=agent_identity,
+        run_id=run_id,
+        reason=reason,
+    )
+    try:
+        comment = find_mission_state_comment(
+            client.list_issue_comments(issue_number),
+            issue_number=issue_number,
+            branch=branch,
+        )
+        if comment is None:
+            client.create_issue_comment(issue_number, body)
+            return
+        client.update_issue_comment(int(comment["id"]), body)
+    except (GitHubClientError, KeyError, TypeError, ValueError) as error:
+        raise MissionPublishError(
+            f"failed to upsert publish failure comment for issue #{issue_number}: {error}"
         ) from error
 
 
@@ -608,4 +668,31 @@ def render_publish_comment(
         "Shinobi Publish\n\n"
         f"任務 #{issue_number} の draft PR を公開しました。\n"
         f"- pr: #{pr_number}\n"
+    )
+
+
+def render_publish_failure_state_comment(
+    *,
+    issue_number: int,
+    branch: str,
+    pr_number: int,
+    lease_expires_at: str,
+    agent_identity: str,
+    run_id: str,
+    reason: str,
+) -> str:
+    return (
+        "<!-- shinobi:mission-state\n"
+        f"issue: {issue_number}\n"
+        f"branch: {branch}\n"
+        "phase: publish\n"
+        f"pr: {pr_number}\n"
+        f"lease_expires_at: {lease_expires_at}\n"
+        f"agent_identity: {agent_identity}\n"
+        f"run_id: {run_id}\n"
+        "-->\n"
+        "Shinobi Publish Handoff\n\n"
+        f"任務 #{issue_number} の publish 中に人手対応が必要になりました。\n"
+        f"- pr: #{pr_number}\n"
+        f"- reason: {reason}\n"
     )

--- a/src/shinobi/state_store.py
+++ b/src/shinobi/state_store.py
@@ -329,6 +329,32 @@ class StateStore:
                 )
             return lock
 
+    def refresh_lock_heartbeat(
+        self,
+        *,
+        run_id: str,
+        agent_identity: str,
+        now: datetime,
+    ) -> RunLock:
+        self.paths.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.paths.lock_path.open("a+", encoding="utf-8") as lock_file:
+            self._lock_file(lock_file)
+            try:
+                lock = self._load_lock_from_file(lock_file)
+            except (JSONDecodeError, TypeError, ValueError) as error:
+                raise ValueError(f"failed to load run lock: {error}") from error
+            if lock is None:
+                raise RuntimeError("run lock is missing before heartbeat update")
+            if lock.run_id != run_id or lock.agent_identity != agent_identity:
+                raise RuntimeError(
+                    "run lock owner changed before heartbeat update "
+                    f"(expected {run_id}/{agent_identity}, got {lock.run_id}/{lock.agent_identity})"
+                )
+
+            lock.heartbeat_at = self.format_timestamp(now)
+            self._write_lock_to_file(lock_file, lock)
+            return lock
+
     def acquire_lock(
         self,
         *,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,7 @@ from shinobi.executor import execute_verification, run_verification_command
 from shinobi.github_client import GitHubClient, GitHubClientError
 from shinobi.mission_publish import (
     MissionPublishError,
+    build_same_repo_head_selector,
     find_mission_state_comment,
     parse_mission_state_fields,
     publish_mission,
@@ -1973,6 +1974,9 @@ class MissionPublishTest(unittest.TestCase):
             client.create_pull_request.assert_not_called()
             client.update_pull_request.assert_called_once()
             client.convert_pull_request_to_draft.assert_not_called()
+            client.list_pull_requests_by_head.assert_called_once_with(
+                "owner:feature/issue-31-publish-phase"
+            )
             client.create_issue_comment.assert_called_once()
 
     def test_publish_mission_converts_existing_pr_back_to_draft(self) -> None:
@@ -2051,6 +2055,9 @@ class MissionPublishTest(unittest.TestCase):
             client.create_pull_request.assert_not_called()
             client.update_pull_request.assert_called_once()
             client.convert_pull_request_to_draft.assert_called_once_with(44)
+            client.list_pull_requests_by_head.assert_called_once_with(
+                "owner:feature/issue-31-publish-phase"
+            )
             client.create_issue_comment.assert_called_once()
 
     def test_publish_mission_hands_off_when_publish_label_cleanup_fails(self) -> None:
@@ -2613,6 +2620,18 @@ class MissionPublishTest(unittest.TestCase):
         self.assertEqual(fields["issue"], "31")
         self.assertEqual(fields["branch"], "feature/issue-31-publish-phase")
         self.assertEqual(fields["phase"], "publish")
+
+    def test_build_same_repo_head_selector_uses_repo_owner(self) -> None:
+        self.assertEqual(
+            build_same_repo_head_selector("owner/repo", "feature/issue-31-publish-phase"),
+            "owner:feature/issue-31-publish-phase",
+        )
+
+    def test_build_same_repo_head_selector_falls_back_without_owner(self) -> None:
+        self.assertEqual(
+            build_same_repo_head_selector("owner-repo", "feature/issue-31-publish-phase"),
+            "feature/issue-31-publish-phase",
+        )
 
 
 class ContextBuilderTest(unittest.TestCase):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1857,7 +1857,6 @@ class MissionPublishTest(unittest.TestCase):
                         "labels": [
                             {"name": "shinobi:ready"},
                             {"name": "shinobi:working"},
-                            {"name": "shinobi:blocked"},
                             {"name": "shinobi:risky"},
                         ],
                     }
@@ -1894,7 +1893,7 @@ class MissionPublishTest(unittest.TestCase):
                     unittest.mock.call(31, add=["shinobi:reviewing"]),
                     unittest.mock.call(
                         31,
-                        remove=["shinobi:blocked", "shinobi:ready", "shinobi:working"],
+                        remove=["shinobi:ready", "shinobi:working"],
                     ),
                 ],
             )
@@ -2028,6 +2027,46 @@ class MissionPublishTest(unittest.TestCase):
 
         run_mock.assert_not_called()
         store.require_lock_owner.assert_not_called()
+
+    def test_publish_mission_rejects_blocking_issue_label_before_push(self) -> None:
+        store = Mock()
+        config = Config(repo="owner/repo", agent_identity="agent-1")
+        state = cli.State(
+            issue_number=31,
+            branch="feature/issue-31-publish-phase",
+            agent_identity="agent-1",
+            run_id="run-123",
+            phase="start",
+        )
+        execution_result = ExecutionResult(
+            commands=[],
+            change_summary="Published mission changes.",
+        )
+
+        with patch("shinobi.mission_publish.subprocess.run") as run_mock:
+            with patch("shinobi.mission_publish.GitHubClient") as client_cls:
+                client = client_cls.return_value
+                client.get_issue.return_value = {
+                    "number": 31,
+                    "labels": [{"name": "shinobi:needs-human"}],
+                }
+
+                with self.assertRaisesRegex(
+                    MissionPublishError,
+                    "has blocking label\\(s\\): shinobi:needs-human",
+                ):
+                    publish_mission(
+                        root=Path("/tmp/repo"),
+                        store=store,
+                        config=config,
+                        run_id="run-123",
+                        state=state,
+                        execution_result=execution_result,
+                    )
+
+        run_mock.assert_not_called()
+        client.get_pull_request.assert_not_called()
+        client.create_pull_request.assert_not_called()
 
     def test_publish_mission_rejects_state_from_different_run_before_push(self) -> None:
         store = Mock()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2415,7 +2415,7 @@ class MissionPublishTest(unittest.TestCase):
 
         self.assertIsNone(comment)
 
-    def test_publish_mission_rejects_existing_pr_lookup_failure_before_create(self) -> None:
+    def test_publish_mission_hands_off_when_pr_lookup_fails_after_push(self) -> None:
         store = Mock()
         config = Config(repo="owner/repo", agent_identity="agent-1")
         state = cli.State(
@@ -2436,10 +2436,16 @@ class MissionPublishTest(unittest.TestCase):
         ):
             with patch("shinobi.mission_publish.GitHubClient") as client_cls:
                 client = client_cls.return_value
-                client.get_issue.return_value = {
-                    "number": 31,
-                    "labels": [{"name": "shinobi:working"}],
-                }
+                client.get_issue.side_effect = [
+                    {
+                        "number": 31,
+                        "labels": [{"name": "shinobi:working"}],
+                    },
+                    {
+                        "number": 31,
+                        "labels": [{"name": "shinobi:working"}],
+                    },
+                ]
                 client.list_pull_requests_by_head.side_effect = GitHubClientError(
                     "api unavailable"
                 )
@@ -2458,6 +2464,22 @@ class MissionPublishTest(unittest.TestCase):
                     )
 
         client.create_pull_request.assert_not_called()
+        self.assertEqual(
+            client.update_issue_labels.call_args_list,
+            [
+                unittest.mock.call(31, add=["shinobi:needs-human"]),
+                unittest.mock.call(31, remove=["shinobi:working"]),
+            ],
+        )
+        client.create_issue_comment.assert_called_once()
+        self.assertIn(
+            "failed to complete publish phase after pushing branch",
+            client.create_issue_comment.call_args.args[1],
+        )
+        self.assertIn(
+            "Branch: `feature/issue-31-publish-phase`",
+            client.create_issue_comment.call_args.args[1],
+        )
 
     def test_parse_mission_state_fields_reads_marker_only(self) -> None:
         fields = parse_mission_state_fields(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1966,6 +1966,156 @@ class MissionPublishTest(unittest.TestCase):
             client.update_pull_request.assert_called_once()
             client.create_issue_comment.assert_called_once()
 
+    def test_publish_mission_hands_off_when_publish_label_cleanup_fails(self) -> None:
+        store = Mock()
+        store.format_timestamp.return_value = "2026-04-09T00:30:00Z"
+        config = Config(repo="owner/repo", agent_identity="agent-1")
+        state = cli.State(
+            issue_number=31,
+            branch="feature/issue-31-publish-phase",
+            agent_identity="agent-1",
+            run_id="run-123",
+            phase="start",
+        )
+        execution_result = ExecutionResult(
+            commands=[],
+            change_summary="Published mission changes.",
+        )
+
+        with patch(
+            "shinobi.mission_publish.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+        ):
+            with patch("shinobi.mission_publish.GitHubClient") as client_cls:
+                client = client_cls.return_value
+                client.get_issue.return_value = {
+                    "number": 31,
+                    "labels": [
+                        {"name": "shinobi:ready"},
+                        {"name": "shinobi:working"},
+                    ],
+                }
+                client.list_pull_requests_by_head.return_value = []
+                client.create_pull_request.return_value = {
+                    "number": 44,
+                    "url": "https://github.com/owner/repo/pull/44",
+                }
+                client.update_issue_labels.side_effect = [
+                    None,
+                    GitHubClientError("remove failed"),
+                    None,
+                    None,
+                ]
+
+                with self.assertRaisesRegex(
+                    MissionPublishError,
+                    "failed to normalize publish labels for issue #31",
+                ):
+                    publish_mission(
+                        root=Path("/tmp/repo"),
+                        store=store,
+                        config=config,
+                        run_id="run-123",
+                        state=state,
+                        execution_result=execution_result,
+                    )
+
+        self.assertEqual(
+            client.update_issue_labels.call_args_list,
+            [
+                unittest.mock.call(31, add=["shinobi:reviewing"]),
+                unittest.mock.call(31, remove=["shinobi:ready", "shinobi:working"]),
+                unittest.mock.call(31, add=["shinobi:needs-human"]),
+                unittest.mock.call(
+                    31,
+                    remove=["shinobi:ready", "shinobi:reviewing", "shinobi:working"],
+                ),
+            ],
+        )
+        client.create_issue_comment.assert_called_once()
+        self.assertIn(
+            "failed to complete publish phase",
+            client.create_issue_comment.call_args.args[1],
+        )
+        self.assertIn("PR: #44", client.create_issue_comment.call_args.args[1])
+        client.list_issue_comments.assert_not_called()
+        store.save_state.assert_not_called()
+
+    def test_publish_mission_hands_off_when_final_state_save_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            store = StateStore(root)
+            store.paths.shinobi_dir.mkdir()
+            store.paths.config_path.write_text(
+                json.dumps({"repo": "owner/repo", "agent_identity": "agent-1"}),
+                encoding="utf-8",
+            )
+            store.paths.state_path.write_text(
+                json.dumps({"agent_identity": "agent-1", "phase": "idle"}),
+                encoding="utf-8",
+            )
+            config, _ = store.try_load_config()
+            self.assertIsNotNone(config)
+            now = datetime(2026, 4, 9, 0, 0, tzinfo=timezone.utc)
+            store.acquire_lock(config=config, run_id="run-123", pid=123, now=now)
+            state = cli.State(
+                issue_number=31,
+                branch="feature/issue-31-publish-phase",
+                agent_identity="agent-1",
+                run_id="run-123",
+                phase="start",
+            )
+            execution_result = ExecutionResult(
+                commands=[],
+                change_summary="Published mission changes.",
+            )
+
+            with patch(
+                "shinobi.mission_publish.subprocess.run",
+                return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            ):
+                with patch("shinobi.mission_publish.GitHubClient") as client_cls:
+                    client = client_cls.return_value
+                    client.get_issue.return_value = {
+                        "number": 31,
+                        "labels": [{"name": "shinobi:working"}],
+                    }
+                    client.list_pull_requests_by_head.return_value = []
+                    client.create_pull_request.return_value = {
+                        "number": 44,
+                        "url": "https://github.com/owner/repo/pull/44",
+                    }
+                    client.list_issue_comments.return_value = []
+                    with patch.object(store, "save_state", side_effect=OSError("disk full")):
+                        with self.assertRaisesRegex(
+                            MissionPublishError,
+                            "final local state persistence failed for issue #31: disk full",
+                        ):
+                            publish_mission(
+                                root=root,
+                                store=store,
+                                config=config,
+                                run_id="run-123",
+                                state=state,
+                                execution_result=execution_result,
+                                now=now,
+                            )
+
+        self.assertEqual(
+            client.update_issue_labels.call_args_list,
+            [
+                unittest.mock.call(31, add=["shinobi:reviewing"]),
+                unittest.mock.call(31, remove=["shinobi:working"]),
+                unittest.mock.call(31, add=["shinobi:needs-human"]),
+                unittest.mock.call(31, remove=["shinobi:reviewing", "shinobi:working"]),
+            ],
+        )
+        self.assertEqual(client.create_issue_comment.call_count, 2)
+        self.assertIn(
+            "failed to persist final local state during publish phase",
+            client.create_issue_comment.call_args_list[-1].args[1],
+        )
+
     def test_publish_mission_rejects_non_start_state(self) -> None:
         with self.assertRaisesRegex(
             MissionPublishError,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -467,7 +467,7 @@ class CliTest(unittest.TestCase):
                                                 pr_url="https://github.com/owner/repo/pull/31",
                                                 lease_expires_at="2026-04-09T00:30:00Z",
                                             ),
-                                        ):
+                                        ) as publish_mock:
                                             with redirect_stdout(output):
                                                 exit_code = cli.main(["run"])
 
@@ -478,6 +478,7 @@ class CliTest(unittest.TestCase):
             self.assertIn("started_branch: feature/issue-6-run-start-phase", rendered)
             self.assertIn("published_pr: #31", rendered)
             self.assertIn("next_phase: review", rendered)
+            self.assertNotIn("now", publish_mock.call_args.kwargs)
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
     def test_run_refuses_active_github_mission_before_selecting_ready_issue(self) -> None:
@@ -1750,7 +1751,8 @@ class MissionPublishTest(unittest.TestCase):
             self.assertIsNotNone(config)
             run_id = "run-123"
             now = datetime(2026, 4, 9, 0, 0, tzinfo=timezone.utc)
-            store.acquire_lock(config=config, run_id=run_id, pid=123, now=now)
+            lock_started_at = datetime(2026, 4, 8, 23, 0, tzinfo=timezone.utc)
+            store.acquire_lock(config=config, run_id=run_id, pid=123, now=lock_started_at)
             store.save_state(
                 cli.State(
                     issue_number=31,
@@ -1843,6 +1845,9 @@ class MissionPublishTest(unittest.TestCase):
             self.assertEqual(state.phase, "publish")
             self.assertEqual(state.pr_number, 44)
             self.assertEqual(state.last_result, "published")
+            lock = store.load_lock()
+            self.assertIsNotNone(lock)
+            self.assertEqual(lock.heartbeat_at, "2026-04-09T00:00:00Z")
 
     def test_publish_mission_updates_existing_pr(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1940,11 +1940,13 @@ class MissionPublishTest(unittest.TestCase):
                         {
                             "number": 44,
                             "url": "https://github.com/owner/repo/pull/44",
+                            "isDraft": True,
                         }
                     ]
                     client.update_pull_request.return_value = {
                         "number": 44,
                         "url": "https://github.com/owner/repo/pull/44",
+                        "isDraft": True,
                     }
                     client.get_issue.side_effect = [
                         {
@@ -1970,6 +1972,85 @@ class MissionPublishTest(unittest.TestCase):
 
             client.create_pull_request.assert_not_called()
             client.update_pull_request.assert_called_once()
+            client.convert_pull_request_to_draft.assert_not_called()
+            client.create_issue_comment.assert_called_once()
+
+    def test_publish_mission_converts_existing_pr_back_to_draft(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            store = StateStore(root)
+            store.paths.shinobi_dir.mkdir()
+            store.paths.config_path.write_text(
+                json.dumps({"repo": "owner/repo", "agent_identity": "agent-1"}),
+                encoding="utf-8",
+            )
+            store.paths.state_path.write_text(
+                json.dumps({"agent_identity": "agent-1", "phase": "idle"}),
+                encoding="utf-8",
+            )
+            config, _ = store.try_load_config()
+            self.assertIsNotNone(config)
+            now = datetime(2026, 4, 9, 0, 0, tzinfo=timezone.utc)
+            store.acquire_lock(config=config, run_id="run-123", pid=123, now=now)
+            state = cli.State(
+                issue_number=31,
+                branch="feature/issue-31-publish-phase",
+                agent_identity="agent-1",
+                run_id="run-123",
+                phase="start",
+            )
+            execution_result = Mock()
+            execution_result.change_summary = "Published mission changes."
+            execution_result.commands = []
+
+            with patch(
+                "shinobi.mission_publish.subprocess.run",
+                return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            ):
+                with patch("shinobi.mission_publish.GitHubClient") as client_cls:
+                    client = client_cls.return_value
+                    client.list_pull_requests_by_head.return_value = [
+                        {
+                            "number": 44,
+                            "url": "https://github.com/owner/repo/pull/44",
+                            "isDraft": False,
+                        }
+                    ]
+                    client.update_pull_request.return_value = {
+                        "number": 44,
+                        "url": "https://github.com/owner/repo/pull/44",
+                        "isDraft": False,
+                    }
+                    client.convert_pull_request_to_draft.return_value = {
+                        "number": 44,
+                        "url": "https://github.com/owner/repo/pull/44",
+                        "isDraft": True,
+                    }
+                    client.get_issue.side_effect = [
+                        {
+                            "number": 31,
+                            "labels": [{"name": "shinobi:working"}],
+                        },
+                        {
+                            "number": 31,
+                            "labels": [{"name": "shinobi:reviewing"}],
+                        },
+                    ]
+                    client.list_issue_comments.return_value = []
+
+                    publish_mission(
+                        root=root,
+                        store=store,
+                        config=config,
+                        run_id="run-123",
+                        state=state,
+                        execution_result=execution_result,
+                        now=now,
+                    )
+
+            client.create_pull_request.assert_not_called()
+            client.update_pull_request.assert_called_once()
+            client.convert_pull_request_to_draft.assert_called_once_with(44)
             client.create_issue_comment.assert_called_once()
 
     def test_publish_mission_hands_off_when_publish_label_cleanup_fails(self) -> None:
@@ -3157,6 +3238,41 @@ class GitHubClientTest(unittest.TestCase):
                     "failed to parse PR list for head feature/issue-25",
                 ):
                     client.list_pull_requests_by_head("feature/issue-25")
+
+    def test_convert_pull_request_to_draft_fetches_updated_pr_metadata(self) -> None:
+        responses = [
+            subprocess.CompletedProcess(
+                args=["gh", "pr", "ready", "42", "--undo"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["gh", "pr", "view", "42"],
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "number": 42,
+                        "url": "https://github.com/owner/repo/pull/42",
+                        "isDraft": True,
+                        "headRefName": "feature/issue-25",
+                        "baseRefName": "main",
+                    }
+                ),
+                stderr="",
+            ),
+        ]
+
+        with patch("shinobi.github_client.discover_repo_slug", return_value="owner/repo"):
+            with patch("shinobi.github_client.subprocess.run", side_effect=responses) as run_mock:
+                client = GitHubClient(Path("/tmp/repo"))
+                pr = client.convert_pull_request_to_draft(42)
+
+        self.assertEqual(pr["number"], 42)
+        self.assertEqual(run_mock.call_count, 2)
+        ready_command = run_mock.call_args_list[0].args[0]
+        self.assertEqual(ready_command[:4], ["gh", "pr", "ready", "42"])
+        self.assertIn("--undo", ready_command)
 
     def test_init_keeps_shinobi_directory_ignored_by_git(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2661,15 +2661,64 @@ class MissionPublishTest(unittest.TestCase):
         run_mock.assert_not_called()
         client.list_pull_requests_by_head.assert_not_called()
         client.create_pull_request.assert_not_called()
-        self.assertEqual(
-            client.update_issue_labels.call_args_list,
-            [
-                unittest.mock.call(31, add=["shinobi:needs-human"]),
-                unittest.mock.call(31, remove=["shinobi:working"]),
-            ],
-        )
-        client.create_issue_comment.assert_called_once()
+        client.update_issue_labels.assert_not_called()
+        client.create_issue_comment.assert_not_called()
         store.save_state.assert_called_once()
+        saved_state = store.save_state.call_args.args[0]
+        self.assertEqual(saved_state.phase, "idle")
+        self.assertEqual(saved_state.last_result, "needs-human")
+        self.assertEqual(saved_state.last_mission.issue_number, 31)
+        self.assertEqual(saved_state.last_mission.branch, "feature/issue-31-publish-phase")
+        self.assertEqual(saved_state.last_mission.phase, "publish")
+        self.assertEqual(saved_state.last_mission.conclusion, "needs-human")
+
+    def test_publish_mission_preserves_blocked_label_before_push(self) -> None:
+        store = Mock()
+        config = Config(repo="owner/repo", agent_identity="agent-1")
+        state = cli.State(
+            issue_number=31,
+            branch="feature/issue-31-publish-phase",
+            agent_identity="agent-1",
+            run_id="run-123",
+            phase="start",
+        )
+        execution_result = ExecutionResult(
+            commands=[],
+            change_summary="Published mission changes.",
+        )
+
+        with patch("shinobi.mission_publish.subprocess.run") as run_mock:
+            with patch("shinobi.mission_publish.GitHubClient") as client_cls:
+                client = client_cls.return_value
+                client.get_issue.return_value = {
+                    "number": 31,
+                    "labels": [{"name": "shinobi:blocked"}],
+                }
+
+                with self.assertRaisesRegex(
+                    MissionPublishError,
+                    "has blocking label\\(s\\): shinobi:blocked",
+                ):
+                    publish_mission(
+                        root=Path("/tmp/repo"),
+                        store=store,
+                        config=config,
+                        run_id="run-123",
+                        state=state,
+                        execution_result=execution_result,
+                    )
+
+        run_mock.assert_not_called()
+        client.update_issue_labels.assert_not_called()
+        client.create_issue_comment.assert_not_called()
+        store.save_state.assert_called_once()
+        saved_state = store.save_state.call_args.args[0]
+        self.assertEqual(saved_state.phase, "idle")
+        self.assertEqual(saved_state.last_result, "blocked")
+        self.assertEqual(saved_state.last_mission.issue_number, 31)
+        self.assertEqual(saved_state.last_mission.branch, "feature/issue-31-publish-phase")
+        self.assertEqual(saved_state.last_mission.phase, "publish")
+        self.assertEqual(saved_state.last_mission.conclusion, "blocked")
 
     def test_publish_mission_hands_off_when_push_fails_before_pr_creation(self) -> None:
         store = Mock()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1841,13 +1841,7 @@ class MissionPublishTest(unittest.TestCase):
             ):
                 with patch("shinobi.mission_publish.GitHubClient") as client_cls:
                     client = client_cls.return_value
-                    client.get_pull_request.side_effect = [
-                        GitHubClientError("no PR found"),
-                        {
-                            "number": 44,
-                            "url": "https://github.com/owner/repo/pull/44",
-                        },
-                    ]
+                    client.list_pull_requests_by_head.return_value = []
                     client.create_pull_request.return_value = {
                         "number": 44,
                         "url": "https://github.com/owner/repo/pull/44",
@@ -1942,10 +1936,12 @@ class MissionPublishTest(unittest.TestCase):
             ):
                 with patch("shinobi.mission_publish.GitHubClient") as client_cls:
                     client = client_cls.return_value
-                    client.get_pull_request.return_value = {
-                        "number": 44,
-                        "url": "https://github.com/owner/repo/pull/44",
-                    }
+                    client.list_pull_requests_by_head.return_value = [
+                        {
+                            "number": 44,
+                            "url": "https://github.com/owner/repo/pull/44",
+                        }
+                    ]
                     client.update_pull_request.return_value = {
                         "number": 44,
                         "url": "https://github.com/owner/repo/pull/44",
@@ -2065,7 +2061,7 @@ class MissionPublishTest(unittest.TestCase):
                     )
 
         run_mock.assert_not_called()
-        client.get_pull_request.assert_not_called()
+        client.list_pull_requests_by_head.assert_not_called()
         client.create_pull_request.assert_not_called()
 
     def test_publish_mission_rejects_state_from_different_run_before_push(self) -> None:
@@ -2178,6 +2174,50 @@ class MissionPublishTest(unittest.TestCase):
         )
 
         self.assertIsNone(comment)
+
+    def test_publish_mission_rejects_existing_pr_lookup_failure_before_create(self) -> None:
+        store = Mock()
+        config = Config(repo="owner/repo", agent_identity="agent-1")
+        state = cli.State(
+            issue_number=31,
+            branch="feature/issue-31-publish-phase",
+            agent_identity="agent-1",
+            run_id="run-123",
+            phase="start",
+        )
+        execution_result = ExecutionResult(
+            commands=[],
+            change_summary="Published mission changes.",
+        )
+
+        with patch(
+            "shinobi.mission_publish.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+        ):
+            with patch("shinobi.mission_publish.GitHubClient") as client_cls:
+                client = client_cls.return_value
+                client.get_issue.return_value = {
+                    "number": 31,
+                    "labels": [{"name": "shinobi:working"}],
+                }
+                client.list_pull_requests_by_head.side_effect = GitHubClientError(
+                    "api unavailable"
+                )
+
+                with self.assertRaisesRegex(
+                    MissionPublishError,
+                    "failed to look up existing PR for issue #31",
+                ):
+                    publish_mission(
+                        root=Path("/tmp/repo"),
+                        store=store,
+                        config=config,
+                        run_id="run-123",
+                        state=state,
+                        execution_result=execution_result,
+                    )
+
+        client.create_pull_request.assert_not_called()
 
     def test_parse_mission_state_fields_reads_marker_only(self) -> None:
         fields = parse_mission_state_fields(
@@ -2807,6 +2847,54 @@ class GitHubClientTest(unittest.TestCase):
         self.assertIn("--draft", create_command)
         self.assertIn("--head", create_command)
         self.assertIn("feature/issue-25", create_command)
+
+    def test_list_pull_requests_by_head_returns_open_prs_for_branch(self) -> None:
+        response = subprocess.CompletedProcess(
+            args=["gh", "pr", "list"],
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    {
+                        "number": 42,
+                        "url": "https://github.com/owner/repo/pull/42",
+                        "isDraft": True,
+                        "headRefName": "feature/issue-25",
+                        "baseRefName": "main",
+                    }
+                ]
+            ),
+            stderr="",
+        )
+
+        with patch("shinobi.github_client.discover_repo_slug", return_value="owner/repo"):
+            with patch("shinobi.github_client.subprocess.run", return_value=response) as run_mock:
+                client = GitHubClient(Path("/tmp/repo"))
+                prs = client.list_pull_requests_by_head("feature/issue-25")
+
+        self.assertEqual(prs[0]["number"], 42)
+        command = run_mock.call_args.args[0]
+        self.assertEqual(command[:3], ["gh", "pr", "list"])
+        self.assertIn("--head", command)
+        self.assertIn("feature/issue-25", command)
+        self.assertIn("--state", command)
+        self.assertIn("open", command)
+
+    def test_list_pull_requests_by_head_rejects_non_list_payload(self) -> None:
+        response = subprocess.CompletedProcess(
+            args=["gh", "pr", "list"],
+            returncode=0,
+            stdout=json.dumps({"number": 42}),
+            stderr="",
+        )
+
+        with patch("shinobi.github_client.discover_repo_slug", return_value="owner/repo"):
+            with patch("shinobi.github_client.subprocess.run", return_value=response):
+                client = GitHubClient(Path("/tmp/repo"))
+                with self.assertRaisesRegex(
+                    GitHubClientError,
+                    "failed to parse PR list for head feature/issue-25",
+                ):
+                    client.list_pull_requests_by_head("feature/issue-25")
 
     def test_init_keeps_shinobi_directory_ignored_by_git(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,7 +34,7 @@ from shinobi.mission_start import (
     handoff_started_mission,
     start_mission,
 )
-from shinobi.models import Config
+from shinobi.models import Config, ExecutionResult, VerificationCommandResult
 from shinobi.state_store import StateStore
 
 
@@ -1924,6 +1924,50 @@ class MissionPublishTest(unittest.TestCase):
                 state=cli.State(issue_number=31, branch="feature/issue-31", phase="idle"),
                 execution_result=Mock(),
             )
+
+    def test_publish_mission_rejects_failed_verification_before_push(self) -> None:
+        store = Mock()
+        config = Config(repo="owner/repo", agent_identity="agent-1")
+        state = cli.State(
+            issue_number=31,
+            branch="feature/issue-31-publish-phase",
+            agent_identity="agent-1",
+            run_id="run-123",
+            phase="start",
+        )
+        execution_result = ExecutionResult(
+            commands=[
+                VerificationCommandResult(
+                    name="lint",
+                    command=[],
+                    status="not_configured",
+                ),
+                VerificationCommandResult(
+                    name="test",
+                    command=["python3", "-m", "unittest"],
+                    status="failed",
+                    returncode=1,
+                ),
+            ],
+            change_summary="Published mission changes.",
+        )
+
+        with patch("shinobi.mission_publish.subprocess.run") as run_mock:
+            with self.assertRaisesRegex(
+                MissionPublishError,
+                "test: failed",
+            ):
+                publish_mission(
+                    root=Path("/tmp/repo"),
+                    store=store,
+                    config=config,
+                    run_id="run-123",
+                    state=state,
+                    execution_result=execution_result,
+                )
+
+        run_mock.assert_not_called()
+        store.require_lock_owner.assert_not_called()
 
     def test_find_mission_state_comment_matches_issue_and_branch(self) -> None:
         comment = find_mission_state_comment(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2060,6 +2060,94 @@ class MissionPublishTest(unittest.TestCase):
             )
             client.create_issue_comment.assert_called_once()
 
+    def test_publish_mission_marks_existing_draft_pr_ready_when_config_disables_drafts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            store = StateStore(root)
+            store.paths.shinobi_dir.mkdir()
+            store.paths.config_path.write_text(
+                json.dumps(
+                    {
+                        "repo": "owner/repo",
+                        "agent_identity": "agent-1",
+                        "use_draft_pr": False,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            store.paths.state_path.write_text(
+                json.dumps({"agent_identity": "agent-1", "phase": "idle"}),
+                encoding="utf-8",
+            )
+            config, _ = store.try_load_config()
+            self.assertIsNotNone(config)
+            now = datetime(2026, 4, 9, 0, 0, tzinfo=timezone.utc)
+            store.acquire_lock(config=config, run_id="run-123", pid=123, now=now)
+            state = cli.State(
+                issue_number=31,
+                branch="feature/issue-31-publish-phase",
+                agent_identity="agent-1",
+                run_id="run-123",
+                phase="start",
+            )
+            execution_result = Mock()
+            execution_result.change_summary = "Published mission changes."
+            execution_result.commands = []
+
+            with patch(
+                "shinobi.mission_publish.subprocess.run",
+                return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            ):
+                with patch("shinobi.mission_publish.GitHubClient") as client_cls:
+                    client = client_cls.return_value
+                    client.list_pull_requests_by_head.return_value = [
+                        {
+                            "number": 44,
+                            "url": "https://github.com/owner/repo/pull/44",
+                            "isDraft": True,
+                        }
+                    ]
+                    client.update_pull_request.return_value = {
+                        "number": 44,
+                        "url": "https://github.com/owner/repo/pull/44",
+                        "isDraft": True,
+                    }
+                    client.convert_pull_request_to_ready.return_value = {
+                        "number": 44,
+                        "url": "https://github.com/owner/repo/pull/44",
+                        "isDraft": False,
+                    }
+                    client.get_issue.side_effect = [
+                        {
+                            "number": 31,
+                            "labels": [{"name": "shinobi:working"}],
+                        },
+                        {
+                            "number": 31,
+                            "labels": [{"name": "shinobi:reviewing"}],
+                        },
+                    ]
+                    client.list_issue_comments.return_value = []
+
+                    publish_mission(
+                        root=root,
+                        store=store,
+                        config=config,
+                        run_id="run-123",
+                        state=state,
+                        execution_result=execution_result,
+                        now=now,
+                    )
+
+            client.create_pull_request.assert_not_called()
+            client.update_pull_request.assert_called_once()
+            client.convert_pull_request_to_ready.assert_called_once_with(44)
+            client.convert_pull_request_to_draft.assert_not_called()
+            client.list_pull_requests_by_head.assert_called_once_with(
+                "owner:feature/issue-31-publish-phase"
+            )
+            client.create_issue_comment.assert_called_once()
+
     def test_publish_mission_hands_off_when_publish_label_cleanup_fails(self) -> None:
         store = Mock()
         store.format_timestamp.return_value = "2026-04-09T00:30:00Z"
@@ -3330,6 +3418,41 @@ class GitHubClientTest(unittest.TestCase):
         ready_command = run_mock.call_args_list[0].args[0]
         self.assertEqual(ready_command[:4], ["gh", "pr", "ready", "42"])
         self.assertIn("--undo", ready_command)
+
+    def test_convert_pull_request_to_ready_fetches_updated_pr_metadata(self) -> None:
+        responses = [
+            subprocess.CompletedProcess(
+                args=["gh", "pr", "ready", "42"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["gh", "pr", "view", "42"],
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "number": 42,
+                        "url": "https://github.com/owner/repo/pull/42",
+                        "isDraft": False,
+                        "headRefName": "feature/issue-25",
+                        "baseRefName": "main",
+                    }
+                ),
+                stderr="",
+            ),
+        ]
+
+        with patch("shinobi.github_client.discover_repo_slug", return_value="owner/repo"):
+            with patch("shinobi.github_client.subprocess.run", side_effect=responses) as run_mock:
+                client = GitHubClient(Path("/tmp/repo"))
+                pr = client.convert_pull_request_to_ready(42)
+
+        self.assertEqual(pr["number"], 42)
+        self.assertEqual(run_mock.call_count, 2)
+        ready_command = run_mock.call_args_list[0].args[0]
+        self.assertEqual(ready_command[:4], ["gh", "pr", "ready", "42"])
+        self.assertNotIn("--undo", ready_command)
 
     def test_init_keeps_shinobi_directory_ignored_by_git(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2136,7 +2136,15 @@ class MissionPublishTest(unittest.TestCase):
         )
         self.assertIn("PR: #44", client.create_issue_comment.call_args.args[1])
         client.list_issue_comments.assert_not_called()
-        store.save_state.assert_not_called()
+        store.save_state.assert_called_once()
+        saved_state = store.save_state.call_args.args[0]
+        self.assertEqual(saved_state.phase, "idle")
+        self.assertEqual(saved_state.last_result, "needs-human")
+        self.assertEqual(saved_state.last_mission.issue_number, 31)
+        self.assertEqual(saved_state.last_mission.pr_number, 44)
+        self.assertEqual(saved_state.last_mission.branch, "feature/issue-31-publish-phase")
+        self.assertEqual(saved_state.last_mission.phase, "publish")
+        self.assertEqual(saved_state.last_mission.conclusion, "needs-human")
 
     def test_publish_mission_hands_off_when_final_state_save_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -2561,6 +2569,15 @@ class MissionPublishTest(unittest.TestCase):
             "Branch: `feature/issue-31-publish-phase`",
             client.create_issue_comment.call_args.args[1],
         )
+        store.save_state.assert_called_once()
+        saved_state = store.save_state.call_args.args[0]
+        self.assertEqual(saved_state.phase, "idle")
+        self.assertEqual(saved_state.last_result, "needs-human")
+        self.assertEqual(saved_state.last_mission.issue_number, 31)
+        self.assertIsNone(saved_state.last_mission.pr_number)
+        self.assertEqual(saved_state.last_mission.branch, "feature/issue-31-publish-phase")
+        self.assertEqual(saved_state.last_mission.phase, "publish")
+        self.assertEqual(saved_state.last_mission.conclusion, "needs-human")
 
     def test_parse_mission_state_fields_reads_marker_only(self) -> None:
         fields = parse_mission_state_fields(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -456,6 +456,7 @@ class CliTest(unittest.TestCase):
                                 ):
                                     execution_result = Mock()
                                     execution_result.succeeded = True
+                                    execution_result.commands = []
                                     with patch(
                                         "shinobi.cli.execute_verification",
                                         return_value=execution_result,
@@ -479,6 +480,65 @@ class CliTest(unittest.TestCase):
             self.assertIn("published_pr: #31", rendered)
             self.assertIn("next_phase: review", rendered)
             self.assertNotIn("now", publish_mock.call_args.kwargs)
+            self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
+
+    def test_run_hands_off_when_verification_fails_before_publish(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    output = io.StringIO()
+                    started_mission = Mock(
+                        branch="feature/issue-6-run-start-phase",
+                        issue_number=6,
+                        lease_expires_at="2026-04-09T00:30:00Z",
+                    )
+                    execution_result = ExecutionResult(
+                        commands=[
+                            VerificationCommandResult(
+                                name="test",
+                                command=["python3", "-m", "unittest"],
+                                status="failed",
+                                returncode=1,
+                            )
+                        ],
+                        change_summary="No automated code changes are performed.",
+                    )
+                    with patch("shinobi.cli.list_open_issues_with_any_label", return_value=[]):
+                        with patch("shinobi.cli.select_ready_issue", return_value=6):
+                            with patch(
+                                "shinobi.cli.load_issue",
+                                return_value={"number": 6, "title": "Run start phase"},
+                            ):
+                                with patch(
+                                    "shinobi.cli.start_mission",
+                                    return_value=started_mission,
+                                ):
+                                    with patch(
+                                        "shinobi.cli.execute_verification",
+                                        return_value=execution_result,
+                                    ):
+                                        with patch(
+                                            "shinobi.cli.handoff_started_mission"
+                                        ) as handoff_mock:
+                                            with patch(
+                                                "shinobi.cli.publish_mission"
+                                            ) as publish_mock:
+                                                with redirect_stdout(output):
+                                                    exit_code = cli.main(["run"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn(
+                "run aborted: Shinobi stopped before publish because verification failed",
+                output.getvalue(),
+            )
+            handoff_mock.assert_called_once()
+            self.assertIn("test: failed", handoff_mock.call_args.kwargs["reason"])
+            publish_mock.assert_not_called()
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
     def test_run_refuses_active_github_mission_before_selecting_ready_issue(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1969,6 +1969,70 @@ class MissionPublishTest(unittest.TestCase):
         run_mock.assert_not_called()
         store.require_lock_owner.assert_not_called()
 
+    def test_publish_mission_rejects_state_from_different_run_before_push(self) -> None:
+        store = Mock()
+        config = Config(repo="owner/repo", agent_identity="agent-1")
+        state = cli.State(
+            issue_number=31,
+            branch="feature/issue-31-publish-phase",
+            agent_identity="agent-1",
+            run_id="previous-run",
+            phase="start",
+        )
+        execution_result = ExecutionResult(
+            commands=[],
+            change_summary="Published mission changes.",
+        )
+
+        with patch("shinobi.mission_publish.subprocess.run") as run_mock:
+            with self.assertRaisesRegex(
+                MissionPublishError,
+                "publish phase requires local state run_id run-123",
+            ):
+                publish_mission(
+                    root=Path("/tmp/repo"),
+                    store=store,
+                    config=config,
+                    run_id="run-123",
+                    state=state,
+                    execution_result=execution_result,
+                )
+
+        run_mock.assert_not_called()
+        store.require_lock_owner.assert_not_called()
+
+    def test_publish_mission_rejects_state_from_different_agent_before_push(self) -> None:
+        store = Mock()
+        config = Config(repo="owner/repo", agent_identity="agent-1")
+        state = cli.State(
+            issue_number=31,
+            branch="feature/issue-31-publish-phase",
+            agent_identity="agent-2",
+            run_id="run-123",
+            phase="start",
+        )
+        execution_result = ExecutionResult(
+            commands=[],
+            change_summary="Published mission changes.",
+        )
+
+        with patch("shinobi.mission_publish.subprocess.run") as run_mock:
+            with self.assertRaisesRegex(
+                MissionPublishError,
+                "publish phase requires local state agent_identity agent-1",
+            ):
+                publish_mission(
+                    root=Path("/tmp/repo"),
+                    store=store,
+                    config=config,
+                    run_id="run-123",
+                    state=state,
+                    execution_result=execution_result,
+                )
+
+        run_mock.assert_not_called()
+        store.require_lock_owner.assert_not_called()
+
     def test_find_mission_state_comment_matches_issue_and_branch(self) -> None:
         comment = find_mission_state_comment(
             [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1942,6 +1942,8 @@ class MissionPublishTest(unittest.TestCase):
                             "number": 44,
                             "url": "https://github.com/owner/repo/pull/44",
                             "isDraft": True,
+                            "headRefName": "feature/issue-31-publish-phase",
+                            "baseRefName": "main",
                         }
                     ]
                     client.update_pull_request.return_value = {
@@ -1978,6 +1980,153 @@ class MissionPublishTest(unittest.TestCase):
                 "owner:feature/issue-31-publish-phase"
             )
             client.create_issue_comment.assert_called_once()
+
+    def test_publish_mission_creates_new_pr_when_existing_head_targets_other_base(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            store = StateStore(root)
+            store.paths.shinobi_dir.mkdir()
+            store.paths.config_path.write_text(
+                json.dumps({"repo": "owner/repo", "agent_identity": "agent-1"}),
+                encoding="utf-8",
+            )
+            store.paths.state_path.write_text(
+                json.dumps({"agent_identity": "agent-1", "phase": "idle"}),
+                encoding="utf-8",
+            )
+            config, _ = store.try_load_config()
+            self.assertIsNotNone(config)
+            now = datetime(2026, 4, 9, 0, 0, tzinfo=timezone.utc)
+            store.acquire_lock(config=config, run_id="run-123", pid=123, now=now)
+            state = cli.State(
+                issue_number=31,
+                branch="feature/issue-31-publish-phase",
+                agent_identity="agent-1",
+                run_id="run-123",
+                phase="start",
+            )
+            execution_result = Mock()
+            execution_result.change_summary = "Published mission changes."
+            execution_result.commands = []
+
+            with patch(
+                "shinobi.mission_publish.subprocess.run",
+                return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            ):
+                with patch("shinobi.mission_publish.GitHubClient") as client_cls:
+                    client = client_cls.return_value
+                    client.list_pull_requests_by_head.return_value = [
+                        {
+                            "number": 44,
+                            "url": "https://github.com/owner/repo/pull/44",
+                            "isDraft": True,
+                            "headRefName": "feature/issue-31-publish-phase",
+                            "baseRefName": "release/1.0",
+                        }
+                    ]
+                    client.create_pull_request.return_value = {
+                        "number": 45,
+                        "url": "https://github.com/owner/repo/pull/45",
+                    }
+                    client.get_issue.side_effect = [
+                        {
+                            "number": 31,
+                            "labels": [{"name": "shinobi:working"}],
+                        },
+                        {
+                            "number": 31,
+                            "labels": [{"name": "shinobi:reviewing"}],
+                        },
+                    ]
+                    client.list_issue_comments.return_value = []
+
+                    publish_mission(
+                        root=root,
+                        store=store,
+                        config=config,
+                        run_id="run-123",
+                        state=state,
+                        execution_result=execution_result,
+                        now=now,
+                    )
+
+            client.update_pull_request.assert_not_called()
+            client.create_pull_request.assert_called_once()
+            self.assertEqual(client.create_pull_request.call_args.kwargs["base"], "main")
+
+    def test_publish_mission_hands_off_when_multiple_open_prs_match_same_base(self) -> None:
+        store = Mock()
+        store.format_timestamp.return_value = "2026-04-09T00:30:00Z"
+        config = Config(repo="owner/repo", agent_identity="agent-1")
+        state = cli.State(
+            issue_number=31,
+            branch="feature/issue-31-publish-phase",
+            agent_identity="agent-1",
+            run_id="run-123",
+            phase="start",
+        )
+        execution_result = ExecutionResult(
+            commands=[],
+            change_summary="Published mission changes.",
+        )
+
+        with patch(
+            "shinobi.mission_publish.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+        ):
+            with patch("shinobi.mission_publish.GitHubClient") as client_cls:
+                client = client_cls.return_value
+                client.get_issue.side_effect = [
+                    {
+                        "number": 31,
+                        "labels": [{"name": "shinobi:working"}],
+                    },
+                    {
+                        "number": 31,
+                        "labels": [{"name": "shinobi:working"}],
+                    },
+                ]
+                client.list_pull_requests_by_head.return_value = [
+                    {
+                        "number": 44,
+                        "url": "https://github.com/owner/repo/pull/44",
+                        "isDraft": True,
+                        "headRefName": "feature/issue-31-publish-phase",
+                        "baseRefName": "main",
+                    },
+                    {
+                        "number": 45,
+                        "url": "https://github.com/owner/repo/pull/45",
+                        "isDraft": True,
+                        "headRefName": "feature/issue-31-publish-phase",
+                        "baseRefName": "main",
+                    },
+                ]
+
+                with self.assertRaisesRegex(
+                    MissionPublishError,
+                    "multiple open PRs match feature/issue-31-publish-phase -> main",
+                ):
+                    publish_mission(
+                        root=Path("/tmp/repo"),
+                        store=store,
+                        config=config,
+                        run_id="run-123",
+                        state=state,
+                        execution_result=execution_result,
+                    )
+
+        client.update_pull_request.assert_not_called()
+        client.create_pull_request.assert_not_called()
+        self.assertEqual(
+            client.update_issue_labels.call_args_list,
+            [
+                unittest.mock.call(31, add=["shinobi:needs-human"]),
+                unittest.mock.call(31, remove=["shinobi:working"]),
+            ],
+        )
+        client.create_issue_comment.assert_called_once()
+        store.save_state.assert_called_once()
 
     def test_publish_mission_converts_existing_pr_back_to_draft(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -2018,6 +2167,8 @@ class MissionPublishTest(unittest.TestCase):
                             "number": 44,
                             "url": "https://github.com/owner/repo/pull/44",
                             "isDraft": False,
+                            "headRefName": "feature/issue-31-publish-phase",
+                            "baseRefName": "main",
                         }
                     ]
                     client.update_pull_request.return_value = {
@@ -2105,6 +2256,8 @@ class MissionPublishTest(unittest.TestCase):
                             "number": 44,
                             "url": "https://github.com/owner/repo/pull/44",
                             "isDraft": True,
+                            "headRefName": "feature/issue-31-publish-phase",
+                            "baseRefName": "main",
                         }
                     ]
                     client.update_pull_request.return_value = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2103,6 +2103,18 @@ class MissionPublishTest(unittest.TestCase):
                     None,
                     None,
                 ]
+                client.list_issue_comments.return_value = [
+                    {
+                        "id": 9001,
+                        "body": (
+                            "<!-- shinobi:mission-state\n"
+                            "issue: 31\n"
+                            "branch: feature/issue-31-publish-phase\n"
+                            "phase: start\n"
+                            "-->\n"
+                        ),
+                    }
+                ]
 
                 with self.assertRaisesRegex(
                     MissionPublishError,
@@ -2129,13 +2141,13 @@ class MissionPublishTest(unittest.TestCase):
                 ),
             ],
         )
-        client.create_issue_comment.assert_called_once()
+        client.update_issue_comment.assert_called_once()
         self.assertIn(
             "failed to complete publish phase",
-            client.create_issue_comment.call_args.args[1],
+            client.update_issue_comment.call_args.args[1],
         )
-        self.assertIn("PR: #44", client.create_issue_comment.call_args.args[1])
-        client.list_issue_comments.assert_not_called()
+        self.assertIn("phase: publish", client.update_issue_comment.call_args.args[1])
+        self.assertIn("pr: 44", client.update_issue_comment.call_args.args[1])
         store.save_state.assert_called_once()
         saved_state = store.save_state.call_args.args[0]
         self.assertEqual(saved_state.phase, "idle")
@@ -2196,7 +2208,18 @@ class MissionPublishTest(unittest.TestCase):
                         "number": 44,
                         "url": "https://github.com/owner/repo/pull/44",
                     }
-                    client.list_issue_comments.return_value = []
+                    client.list_issue_comments.return_value = [
+                        {
+                            "id": 9001,
+                            "body": (
+                                "<!-- shinobi:mission-state\n"
+                                "issue: 31\n"
+                                "branch: feature/issue-31-publish-phase\n"
+                                "phase: start\n"
+                                "-->\n"
+                            ),
+                        }
+                    ]
                     with patch.object(store, "save_state", side_effect=OSError("disk full")):
                         with self.assertRaisesRegex(
                             MissionPublishError,
@@ -2221,10 +2244,11 @@ class MissionPublishTest(unittest.TestCase):
                 unittest.mock.call(31, remove=["shinobi:reviewing"]),
             ],
         )
-        self.assertEqual(client.create_issue_comment.call_count, 2)
+        self.assertEqual(client.create_issue_comment.call_count, 0)
+        self.assertEqual(client.update_issue_comment.call_count, 2)
         self.assertIn(
             "failed to persist final local state during publish phase",
-            client.create_issue_comment.call_args_list[-1].args[1],
+            client.update_issue_comment.call_args_list[-1].args[1],
         )
 
     def test_publish_mission_still_comments_when_handoff_label_cleanup_fails(self) -> None:
@@ -2277,7 +2301,7 @@ class MissionPublishTest(unittest.TestCase):
 
                 with self.assertRaisesRegex(
                     MissionPublishError,
-                    "failed to hand off publish failure: remove failed",
+                    "failed to hand off publish failure: remove failed; failed to upsert publish failure comment for issue #31: comments failed",
                 ):
                     publish_mission(
                         root=Path("/tmp/repo"),
@@ -2288,11 +2312,8 @@ class MissionPublishTest(unittest.TestCase):
                         execution_result=execution_result,
                     )
 
-        client.create_issue_comment.assert_called_once()
-        self.assertIn(
-            "failed to complete publish phase",
-            client.create_issue_comment.call_args.args[1],
-        )
+        client.create_issue_comment.assert_not_called()
+        client.update_issue_comment.assert_not_called()
         store.save_state.assert_not_called()
 
     def test_publish_mission_rejects_non_start_state(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1946,10 +1946,16 @@ class MissionPublishTest(unittest.TestCase):
                         "number": 44,
                         "url": "https://github.com/owner/repo/pull/44",
                     }
-                    client.get_issue.return_value = {
-                        "number": 31,
-                        "labels": [{"name": "shinobi:working"}],
-                    }
+                    client.get_issue.side_effect = [
+                        {
+                            "number": 31,
+                            "labels": [{"name": "shinobi:working"}],
+                        },
+                        {
+                            "number": 31,
+                            "labels": [{"name": "shinobi:reviewing"}],
+                        },
+                    ]
                     client.list_issue_comments.return_value = []
 
                     publish_mission(
@@ -1988,13 +1994,23 @@ class MissionPublishTest(unittest.TestCase):
         ):
             with patch("shinobi.mission_publish.GitHubClient") as client_cls:
                 client = client_cls.return_value
-                client.get_issue.return_value = {
-                    "number": 31,
-                    "labels": [
-                        {"name": "shinobi:ready"},
-                        {"name": "shinobi:working"},
-                    ],
-                }
+                client.get_issue.side_effect = [
+                    {
+                        "number": 31,
+                        "labels": [
+                            {"name": "shinobi:ready"},
+                            {"name": "shinobi:working"},
+                        ],
+                    },
+                    {
+                        "number": 31,
+                        "labels": [
+                            {"name": "shinobi:ready"},
+                            {"name": "shinobi:working"},
+                            {"name": "shinobi:reviewing"},
+                        ],
+                    },
+                ]
                 client.list_pull_requests_by_head.return_value = []
                 client.create_pull_request.return_value = {
                     "number": 44,
@@ -2076,10 +2092,16 @@ class MissionPublishTest(unittest.TestCase):
             ):
                 with patch("shinobi.mission_publish.GitHubClient") as client_cls:
                     client = client_cls.return_value
-                    client.get_issue.return_value = {
-                        "number": 31,
-                        "labels": [{"name": "shinobi:working"}],
-                    }
+                    client.get_issue.side_effect = [
+                        {
+                            "number": 31,
+                            "labels": [{"name": "shinobi:working"}],
+                        },
+                        {
+                            "number": 31,
+                            "labels": [{"name": "shinobi:reviewing"}],
+                        },
+                    ]
                     client.list_pull_requests_by_head.return_value = []
                     client.create_pull_request.return_value = {
                         "number": 44,
@@ -2107,7 +2129,7 @@ class MissionPublishTest(unittest.TestCase):
                 unittest.mock.call(31, add=["shinobi:reviewing"]),
                 unittest.mock.call(31, remove=["shinobi:working"]),
                 unittest.mock.call(31, add=["shinobi:needs-human"]),
-                unittest.mock.call(31, remove=["shinobi:reviewing", "shinobi:working"]),
+                unittest.mock.call(31, remove=["shinobi:reviewing"]),
             ],
         )
         self.assertEqual(client.create_issue_comment.call_count, 2)
@@ -2115,6 +2137,74 @@ class MissionPublishTest(unittest.TestCase):
             "failed to persist final local state during publish phase",
             client.create_issue_comment.call_args_list[-1].args[1],
         )
+
+    def test_publish_mission_still_comments_when_handoff_label_cleanup_fails(self) -> None:
+        store = Mock()
+        store.format_timestamp.return_value = "2026-04-09T00:30:00Z"
+        config = Config(repo="owner/repo", agent_identity="agent-1")
+        state = cli.State(
+            issue_number=31,
+            branch="feature/issue-31-publish-phase",
+            agent_identity="agent-1",
+            run_id="run-123",
+            phase="start",
+        )
+        execution_result = ExecutionResult(
+            commands=[],
+            change_summary="Published mission changes.",
+        )
+
+        with patch(
+            "shinobi.mission_publish.subprocess.run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+        ):
+            with patch("shinobi.mission_publish.GitHubClient") as client_cls:
+                client = client_cls.return_value
+                client.get_issue.side_effect = [
+                    {
+                        "number": 31,
+                        "labels": [{"name": "shinobi:working"}],
+                    },
+                    {
+                        "number": 31,
+                        "labels": [
+                            {"name": "shinobi:working"},
+                            {"name": "shinobi:reviewing"},
+                        ],
+                    },
+                ]
+                client.list_pull_requests_by_head.return_value = []
+                client.create_pull_request.return_value = {
+                    "number": 44,
+                    "url": "https://github.com/owner/repo/pull/44",
+                }
+                client.update_issue_labels.side_effect = [
+                    None,
+                    None,
+                    None,
+                    GitHubClientError("remove failed"),
+                ]
+                client.list_issue_comments.side_effect = GitHubClientError("comments failed")
+
+                with self.assertRaisesRegex(
+                    MissionPublishError,
+                    "failed to hand off publish failure: remove failed",
+                ):
+                    publish_mission(
+                        root=Path("/tmp/repo"),
+                        store=store,
+                        config=config,
+                        run_id="run-123",
+                        state=state,
+                        execution_result=execution_result,
+                    )
+
+        client.create_issue_comment.assert_called_once()
+        self.assertIn(
+            "failed to complete publish phase",
+            client.create_issue_comment.call_args.args[1],
+        )
+        store.save_state.assert_not_called()
 
     def test_publish_mission_rejects_non_start_state(self) -> None:
         with self.assertRaisesRegex(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1977,7 +1977,7 @@ class MissionPublishTest(unittest.TestCase):
             client.update_pull_request.assert_called_once()
             client.convert_pull_request_to_draft.assert_not_called()
             client.list_pull_requests_by_head.assert_called_once_with(
-                "owner:feature/issue-31-publish-phase"
+                "feature/issue-31-publish-phase"
             )
             client.create_issue_comment.assert_called_once()
 
@@ -2207,7 +2207,7 @@ class MissionPublishTest(unittest.TestCase):
             client.update_pull_request.assert_called_once()
             client.convert_pull_request_to_draft.assert_called_once_with(44)
             client.list_pull_requests_by_head.assert_called_once_with(
-                "owner:feature/issue-31-publish-phase"
+                "feature/issue-31-publish-phase"
             )
             client.create_issue_comment.assert_called_once()
 
@@ -2297,7 +2297,7 @@ class MissionPublishTest(unittest.TestCase):
             client.convert_pull_request_to_ready.assert_called_once_with(44)
             client.convert_pull_request_to_draft.assert_not_called()
             client.list_pull_requests_by_head.assert_called_once_with(
-                "owner:feature/issue-31-publish-phase"
+                "feature/issue-31-publish-phase"
             )
             client.create_issue_comment.assert_called_once()
 
@@ -2988,10 +2988,10 @@ class MissionPublishTest(unittest.TestCase):
         self.assertEqual(fields["branch"], "feature/issue-31-publish-phase")
         self.assertEqual(fields["phase"], "publish")
 
-    def test_build_same_repo_head_selector_uses_repo_owner(self) -> None:
+    def test_build_same_repo_head_selector_uses_plain_branch_name(self) -> None:
         self.assertEqual(
             build_same_repo_head_selector("owner/repo", "feature/issue-31-publish-phase"),
-            "owner:feature/issue-31-publish-phase",
+            "feature/issue-31-publish-phase",
         )
 
     def test_build_same_repo_head_selector_falls_back_without_owner(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2508,6 +2508,83 @@ class MissionPublishTest(unittest.TestCase):
         run_mock.assert_not_called()
         client.list_pull_requests_by_head.assert_not_called()
         client.create_pull_request.assert_not_called()
+        self.assertEqual(
+            client.update_issue_labels.call_args_list,
+            [
+                unittest.mock.call(31, add=["shinobi:needs-human"]),
+                unittest.mock.call(31, remove=["shinobi:working"]),
+            ],
+        )
+        client.create_issue_comment.assert_called_once()
+        store.save_state.assert_called_once()
+
+    def test_publish_mission_hands_off_when_push_fails_before_pr_creation(self) -> None:
+        store = Mock()
+        store.format_timestamp.return_value = "2026-04-09T00:30:00Z"
+        config = Config(repo="owner/repo", agent_identity="agent-1")
+        state = cli.State(
+            issue_number=31,
+            branch="feature/issue-31-publish-phase",
+            agent_identity="agent-1",
+            run_id="run-123",
+            phase="start",
+        )
+        execution_result = ExecutionResult(
+            commands=[],
+            change_summary="Published mission changes.",
+        )
+
+        with patch(
+            "shinobi.mission_publish.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                args=["git", "push", "-u", "origin", "feature/issue-31-publish-phase"],
+                returncode=1,
+                stdout="",
+                stderr="non-fast-forward",
+            ),
+        ):
+            with patch("shinobi.mission_publish.GitHubClient") as client_cls:
+                client = client_cls.return_value
+                client.get_issue.return_value = {
+                    "number": 31,
+                    "labels": [{"name": "shinobi:working"}],
+                }
+
+                with self.assertRaisesRegex(
+                    MissionPublishError,
+                    "failed to push branch feature/issue-31-publish-phase: non-fast-forward",
+                ):
+                    publish_mission(
+                        root=Path("/tmp/repo"),
+                        store=store,
+                        config=config,
+                        run_id="run-123",
+                        state=state,
+                        execution_result=execution_result,
+                    )
+
+        client.list_pull_requests_by_head.assert_not_called()
+        client.create_pull_request.assert_not_called()
+        self.assertEqual(
+            client.update_issue_labels.call_args_list,
+            [
+                unittest.mock.call(31, add=["shinobi:needs-human"]),
+                unittest.mock.call(31, remove=["shinobi:working"]),
+            ],
+        )
+        client.create_issue_comment.assert_called_once()
+        self.assertIn(
+            "failed to complete publish phase before creating or updating a PR",
+            client.create_issue_comment.call_args.args[1],
+        )
+        store.save_state.assert_called_once()
+        saved_state = store.save_state.call_args.args[0]
+        self.assertEqual(saved_state.phase, "idle")
+        self.assertEqual(saved_state.last_result, "needs-human")
+        self.assertEqual(saved_state.last_mission.issue_number, 31)
+        self.assertEqual(saved_state.last_mission.branch, "feature/issue-31-publish-phase")
+        self.assertEqual(saved_state.last_mission.phase, "publish")
+        self.assertEqual(saved_state.last_mission.conclusion, "needs-human")
 
     def test_publish_mission_rejects_state_from_different_run_before_push(self) -> None:
         store = Mock()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,12 @@ from shinobi.config import discover_repo_slug
 from shinobi.context_builder import build_mission_context
 from shinobi.executor import execute_verification, run_verification_command
 from shinobi.github_client import GitHubClient, GitHubClientError
+from shinobi.mission_publish import (
+    MissionPublishError,
+    find_mission_state_comment,
+    parse_mission_state_fields,
+    publish_mission,
+)
 from shinobi.mission_start import (
     MissionStartError,
     StartedMission,
@@ -448,16 +454,30 @@ class CliTest(unittest.TestCase):
                                         lease_expires_at="2026-04-09T00:30:00Z",
                                     ),
                                 ):
-                                    with patch("shinobi.cli.handoff_started_mission"):
-                                        with redirect_stdout(output):
-                                            exit_code = cli.main(["run"])
+                                    execution_result = Mock()
+                                    execution_result.succeeded = True
+                                    with patch(
+                                        "shinobi.cli.execute_verification",
+                                        return_value=execution_result,
+                                    ):
+                                        with patch(
+                                            "shinobi.cli.publish_mission",
+                                            return_value=Mock(
+                                                pr_number=31,
+                                                pr_url="https://github.com/owner/repo/pull/31",
+                                                lease_expires_at="2026-04-09T00:30:00Z",
+                                            ),
+                                        ):
+                                            with redirect_stdout(output):
+                                                exit_code = cli.main(["run"])
 
             self.assertEqual(exit_code, 0)
             rendered = output.getvalue()
             self.assertIn("run lock: took over stale lock during select phase", rendered)
             self.assertIn("selected_issue: 6", rendered)
             self.assertIn("started_branch: feature/issue-6-run-start-phase", rendered)
-            self.assertIn("next_phase: manual-handoff", rendered)
+            self.assertIn("published_pr: #31", rendered)
+            self.assertIn("next_phase: review", rendered)
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
     def test_run_refuses_active_github_mission_before_selecting_ready_issue(self) -> None:
@@ -1714,6 +1734,252 @@ class MissionStartTest(unittest.TestCase):
                     },
                     now=now,
                 )
+
+
+class MissionPublishTest(unittest.TestCase):
+    def test_publish_mission_pushes_branch_creates_pr_updates_labels_comment_and_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+            store = StateStore(root)
+            config, _ = store.try_load_config()
+            self.assertIsNotNone(config)
+            run_id = "run-123"
+            now = datetime(2026, 4, 9, 0, 0, tzinfo=timezone.utc)
+            store.acquire_lock(config=config, run_id=run_id, pid=123, now=now)
+            store.save_state(
+                cli.State(
+                    issue_number=31,
+                    pr_number=None,
+                    branch="feature/issue-31-publish-phase",
+                    agent_identity=config.agent_identity,
+                    run_id=run_id,
+                    phase="start",
+                    retryable_local_only=False,
+                    lease_expires_at="2026-04-09T00:30:00Z",
+                    last_result="started",
+                )
+            )
+            execution_result = Mock()
+            execution_result.change_summary = "Published mission changes."
+            execution_result.commands = []
+
+            with patch(
+                "shinobi.mission_publish.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    args=["git", "push", "-u", "origin", "feature/issue-31-publish-phase"],
+                    returncode=0,
+                    stdout="",
+                    stderr="",
+                ),
+            ):
+                with patch("shinobi.mission_publish.GitHubClient") as client_cls:
+                    client = client_cls.return_value
+                    client.get_pull_request.side_effect = [
+                        GitHubClientError("no PR found"),
+                        {
+                            "number": 44,
+                            "url": "https://github.com/owner/repo/pull/44",
+                        },
+                    ]
+                    client.create_pull_request.return_value = {
+                        "number": 44,
+                        "url": "https://github.com/owner/repo/pull/44",
+                    }
+                    client.get_issue.return_value = {
+                        "number": 31,
+                        "labels": [
+                            {"name": "shinobi:ready"},
+                            {"name": "shinobi:working"},
+                            {"name": "shinobi:blocked"},
+                            {"name": "shinobi:risky"},
+                        ],
+                    }
+                    client.list_issue_comments.return_value = [
+                        {
+                            "id": 9001,
+                            "body": (
+                                "<!-- shinobi:mission-state\n"
+                                "issue: 31\n"
+                                "branch: feature/issue-31-publish-phase\n"
+                                "phase: start\n"
+                                "-->\n"
+                            ),
+                        }
+                    ]
+
+                    published = publish_mission(
+                        root=root,
+                        store=store,
+                        config=config,
+                        run_id=run_id,
+                        state=store.load_state(),
+                        execution_result=execution_result,
+                        now=now,
+                    )
+
+            self.assertEqual(published.pr_number, 44)
+            self.assertEqual(published.lease_expires_at, "2026-04-09T00:30:00Z")
+            client.create_pull_request.assert_called_once()
+            self.assertTrue(client.create_pull_request.call_args.kwargs["draft"])
+            self.assertEqual(
+                client.update_issue_labels.call_args_list,
+                [
+                    unittest.mock.call(31, add=["shinobi:reviewing"]),
+                    unittest.mock.call(
+                        31,
+                        remove=["shinobi:blocked", "shinobi:ready", "shinobi:working"],
+                    ),
+                ],
+            )
+            client.update_issue_comment.assert_called_once()
+            self.assertIn("phase: publish", client.update_issue_comment.call_args.args[1])
+            self.assertIn("pr: 44", client.update_issue_comment.call_args.args[1])
+            state = store.load_state()
+            self.assertEqual(state.phase, "publish")
+            self.assertEqual(state.pr_number, 44)
+            self.assertEqual(state.last_result, "published")
+
+    def test_publish_mission_updates_existing_pr(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            store = StateStore(root)
+            store.paths.shinobi_dir.mkdir()
+            store.paths.config_path.write_text(
+                json.dumps({"repo": "owner/repo", "agent_identity": "agent-1"}),
+                encoding="utf-8",
+            )
+            store.paths.state_path.write_text(
+                json.dumps({"agent_identity": "agent-1", "phase": "idle"}),
+                encoding="utf-8",
+            )
+            config, _ = store.try_load_config()
+            self.assertIsNotNone(config)
+            now = datetime(2026, 4, 9, 0, 0, tzinfo=timezone.utc)
+            store.acquire_lock(config=config, run_id="run-123", pid=123, now=now)
+            state = cli.State(
+                issue_number=31,
+                branch="feature/issue-31-publish-phase",
+                agent_identity="agent-1",
+                run_id="run-123",
+                phase="start",
+            )
+            execution_result = Mock()
+            execution_result.change_summary = "Published mission changes."
+            execution_result.commands = []
+
+            with patch(
+                "shinobi.mission_publish.subprocess.run",
+                return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            ):
+                with patch("shinobi.mission_publish.GitHubClient") as client_cls:
+                    client = client_cls.return_value
+                    client.get_pull_request.return_value = {
+                        "number": 44,
+                        "url": "https://github.com/owner/repo/pull/44",
+                    }
+                    client.update_pull_request.return_value = {
+                        "number": 44,
+                        "url": "https://github.com/owner/repo/pull/44",
+                    }
+                    client.get_issue.return_value = {
+                        "number": 31,
+                        "labels": [{"name": "shinobi:working"}],
+                    }
+                    client.list_issue_comments.return_value = []
+
+                    publish_mission(
+                        root=root,
+                        store=store,
+                        config=config,
+                        run_id="run-123",
+                        state=state,
+                        execution_result=execution_result,
+                        now=now,
+                    )
+
+            client.create_pull_request.assert_not_called()
+            client.update_pull_request.assert_called_once()
+            client.create_issue_comment.assert_called_once()
+
+    def test_publish_mission_rejects_non_start_state(self) -> None:
+        with self.assertRaisesRegex(
+            MissionPublishError,
+            "publish phase requires local state phase start",
+        ):
+            publish_mission(
+                root=Path("/tmp/repo"),
+                store=Mock(),
+                config=Config(repo="owner/repo", agent_identity="agent-1"),
+                run_id="run-123",
+                state=cli.State(issue_number=31, branch="feature/issue-31", phase="idle"),
+                execution_result=Mock(),
+            )
+
+    def test_find_mission_state_comment_matches_issue_and_branch(self) -> None:
+        comment = find_mission_state_comment(
+            [
+                {
+                    "id": 1,
+                    "body": (
+                        "<!-- shinobi:mission-state\n"
+                        "issue: 30\n"
+                        "branch: feature/issue-30-other\n"
+                        "-->"
+                    ),
+                },
+                {
+                    "id": 2,
+                    "body": (
+                        "<!-- shinobi:mission-state\n"
+                        "issue: 31\n"
+                        "branch: feature/issue-31-publish-phase\n"
+                        "-->"
+                    ),
+                },
+            ],
+            issue_number=31,
+            branch="feature/issue-31-publish-phase",
+        )
+
+        self.assertEqual(comment["id"], 2)
+
+    def test_find_mission_state_comment_does_not_use_partial_issue_match(self) -> None:
+        comment = find_mission_state_comment(
+            [
+                {
+                    "id": 1,
+                    "body": (
+                        "<!-- shinobi:mission-state\n"
+                        "issue: 31\n"
+                        "branch: feature/issue-31-publish-phase\n"
+                        "-->"
+                    ),
+                },
+            ],
+            issue_number=3,
+            branch="feature/issue-31-publish-phase",
+        )
+
+        self.assertIsNone(comment)
+
+    def test_parse_mission_state_fields_reads_marker_only(self) -> None:
+        fields = parse_mission_state_fields(
+            "issue: 999\n"
+            "<!-- shinobi:mission-state\n"
+            "issue: 31\n"
+            "branch: feature/issue-31-publish-phase\n"
+            "phase: publish\n"
+            "-->\n"
+        )
+
+        self.assertEqual(fields["issue"], "31")
+        self.assertEqual(fields["branch"], "feature/issue-31-publish-phase")
+        self.assertEqual(fields["phase"], "publish")
 
 
 class ContextBuilderTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add publish phase support for pushing the mission branch and creating or updating a draft PR
- update publish labels, upsert the mission-state comment, and persist local state as `phase: publish`
- connect `shinobi run` from start through verification into publish and document the new implemented phase

## Testing
- python3 -m unittest tests.test_cli
- env PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m compileall src tests
- git diff --check

## Scope
- Refs #31
- CI polling, diff review, retry loop, finalize, and auto-merge remain out of scope.
