### PR TITLE
Implement GitHub-aware shinobi status

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ shinobi run --issue 123
 
 ## 現在の状態
 
-このリポジトリは foundations 実装に加え、`run` の start / publish phase と context builder を持ちます。現在は `.shinobi/` の初期化、ローカル state/config の保存、`status` のローカル表示、`run` の issue 選択、stale/live lock 判定、branch 作成、start 用 comment 投稿、GitHub label の start 遷移、検証コマンド実行、branch push、draft PR 作成または更新、publish 用 comment / label / state 更新、Issue 由来の最小 context 構築までを持ちます。context phase の run 統合、review loop、自動 merge はこれから実装します。
+このリポジトリは foundations 実装に加え、`run` の start / publish phase と context builder を持ちます。現在は `.shinobi/` の初期化、ローカル state/config の保存、`status` のローカル表示と GitHub 照合、`run` の issue 選択、stale/live lock 判定、branch 作成、start 用 comment 投稿、GitHub label の start 遷移、検証コマンド実行、branch push、draft PR 作成または更新、publish 用 comment / label / state 更新、Issue 由来の最小 context 構築までを持ちます。context phase の run 統合、review loop、自動 merge はこれから実装します。

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import argparse
 import os
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from .config import discover_workspace_root
 from .executor import execute_verification
+from .github_client import GitHubClient, GitHubClientError
 from .issue_selector import (
     ensure_open_issue,
     load_issue,
@@ -29,6 +31,16 @@ from .mission_start import (
 )
 from .models import Config, ExecutionResult, State
 from .state_store import StateStore
+
+
+@dataclass(frozen=True)
+class StatusMissionRef:
+    source: str
+    issue_number: int | None
+    pr_number: int | None
+    branch: str | None
+    phase: str | None
+    conclusion: str | None = None
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -90,15 +102,223 @@ def command_status(root: Path) -> int:
 
     if state is None:
         print(f"warning: failed to load local state: {state_error}")
-        print("github_status: unavailable in foundations MVP")
         return 1
 
+    render_local_status(state)
+    mission_ref = resolve_status_mission_ref(state)
+    render_github_status(root, config, mission_ref)
+    return 0
+
+
+def render_local_status(state: State) -> None:
     print(f"phase: {state.phase}")
     print(f"issue_number: {state.issue_number}")
     print(f"pr_number: {state.pr_number}")
     print(f"branch: {state.branch}")
-    print("github_status: unavailable in foundations MVP")
-    return 0
+
+    if state.last_mission is None:
+        return
+
+    print(f"last_mission_issue_number: {state.last_mission.issue_number}")
+    print(f"last_mission_pr_number: {state.last_mission.pr_number}")
+    print(f"last_mission_branch: {state.last_mission.branch}")
+    print(f"last_mission_phase: {state.last_mission.phase}")
+    print(f"last_mission_conclusion: {state.last_mission.conclusion}")
+
+
+def resolve_status_mission_ref(state: State) -> StatusMissionRef | None:
+    if state.issue_number is not None or state.pr_number is not None or state.branch is not None:
+        return StatusMissionRef(
+            source="active",
+            issue_number=state.issue_number,
+            pr_number=state.pr_number,
+            branch=state.branch,
+            phase=state.phase,
+        )
+
+    if state.last_mission is None:
+        return None
+
+    return StatusMissionRef(
+        source="last_mission",
+        issue_number=state.last_mission.issue_number,
+        pr_number=state.last_mission.pr_number,
+        branch=state.last_mission.branch,
+        phase=state.last_mission.phase,
+        conclusion=state.last_mission.conclusion,
+    )
+
+
+def render_github_status(
+    root: Path,
+    config: Config | None,
+    mission_ref: StatusMissionRef | None,
+) -> None:
+    if config is None:
+        print("github_status: unavailable (config missing)")
+        return
+
+    if mission_ref is None or (
+        mission_ref.issue_number is None
+        and mission_ref.pr_number is None
+        and mission_ref.branch is None
+    ):
+        print("github_status: no active or recent mission to reconcile")
+        return
+
+    print(f"github_status_target: {mission_ref.source}")
+    client = GitHubClient(root, repo=config.repo)
+    issue = load_status_issue(client, mission_ref.issue_number)
+    pull_request = load_status_pull_request(client, mission_ref.pr_number)
+
+    if issue is None and pull_request is None:
+        return
+
+    warnings = build_status_warnings(
+        mission_ref=mission_ref,
+        config=config,
+        issue=issue,
+        pull_request=pull_request,
+    )
+    for warning in warnings:
+        print(f"warning: {warning}")
+
+
+def load_status_issue(
+    client: GitHubClient, issue_number: int | None
+) -> dict[str, Any] | None:
+    if issue_number is None:
+        print("github_issue: unavailable (no tracked issue)")
+        return None
+
+    try:
+        issue = client.get_issue(issue_number)
+    except GitHubClientError as error:
+        print(f"warning: failed to load issue #{issue_number}: {error}")
+        return None
+
+    labels = ", ".join(sorted(get_status_label_names(issue))) or "(none)"
+    print(f"github_issue_number: {issue_number}")
+    print(f"github_issue_state: {issue.get('state', 'unknown')}")
+    print(f"github_issue_labels: {labels}")
+    return issue
+
+
+def load_status_pull_request(
+    client: GitHubClient, pr_number: int | None
+) -> dict[str, Any] | None:
+    if pr_number is None:
+        print("github_pr: unavailable (no tracked PR)")
+        return None
+
+    try:
+        pull_request = client.get_pull_request(str(pr_number))
+    except GitHubClientError as error:
+        print(f"warning: failed to load PR #{pr_number}: {error}")
+        return None
+
+    readiness = "draft" if pull_request.get("isDraft") else "ready"
+    print(f"github_pr_number: {pull_request.get('number', pr_number)}")
+    print(f"github_pr_state: {readiness}")
+    print(f"github_pr_url: {pull_request.get('url', 'unavailable')}")
+    print(f"github_pr_head: {pull_request.get('headRefName', 'unknown')}")
+    print(f"github_pr_base: {pull_request.get('baseRefName', 'unknown')}")
+    return pull_request
+
+
+def get_status_label_names(issue: dict[str, Any]) -> set[str]:
+    return {
+        label.get("name", "")
+        for label in issue.get("labels", [])
+        if isinstance(label, dict)
+    }
+
+
+def build_status_warnings(
+    *,
+    mission_ref: StatusMissionRef,
+    config: Config,
+    issue: dict[str, Any] | None,
+    pull_request: dict[str, Any] | None,
+) -> list[str]:
+    warnings: list[str] = []
+    if issue is not None:
+        warnings.extend(
+            build_issue_status_warnings(
+                mission_ref=mission_ref,
+                config=config,
+                issue=issue,
+            )
+        )
+    if pull_request is not None:
+        warnings.extend(
+            build_pr_status_warnings(
+                mission_ref=mission_ref,
+                config=config,
+                pull_request=pull_request,
+            )
+        )
+    return warnings
+
+
+def build_issue_status_warnings(
+    *, mission_ref: StatusMissionRef, config: Config, issue: dict[str, Any]
+) -> list[str]:
+    warnings: list[str] = []
+    issue_state = str(issue.get("state", "")).upper()
+    if (
+        mission_ref.source == "active"
+        and mission_ref.phase != "idle"
+        and issue_state != "OPEN"
+    ):
+        warnings.append(
+            f"local mission is active in phase {mission_ref.phase} but issue "
+            f"#{mission_ref.issue_number} is {str(issue.get('state', 'unknown')).lower()} on GitHub"
+        )
+
+    expected_label = expected_status_label(mission_ref, config)
+    if expected_label is not None:
+        label_names = get_status_label_names(issue)
+        if expected_label not in label_names:
+            warnings.append(
+                f"issue #{mission_ref.issue_number} is missing expected label {expected_label} "
+                f"for phase {mission_ref.phase}"
+            )
+
+    return warnings
+
+
+def build_pr_status_warnings(
+    *,
+    mission_ref: StatusMissionRef,
+    config: Config,
+    pull_request: dict[str, Any],
+) -> list[str]:
+    warnings: list[str] = []
+    head_ref = pull_request.get("headRefName")
+    if mission_ref.branch is not None and head_ref != mission_ref.branch:
+        warnings.append(
+            f"local branch {mission_ref.branch} does not match GitHub PR head {head_ref}"
+        )
+
+    base_ref = pull_request.get("baseRefName")
+    if base_ref is not None and base_ref != config.main_branch:
+        warnings.append(
+            f"GitHub PR base branch {base_ref} does not match configured main branch "
+            f"{config.main_branch}"
+        )
+
+    return warnings
+
+
+def expected_status_label(mission_ref: StatusMissionRef, config: Config) -> str | None:
+    if mission_ref.source != "active":
+        return None
+    if mission_ref.phase == "start":
+        return config.labels["working"]
+    if mission_ref.phase == "publish":
+        return config.labels["reviewing"]
+    return None
 
 
 def command_run(root: Path, issue_number: Optional[int]) -> int:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,7 +35,7 @@ from shinobi.mission_start import (
     handoff_started_mission,
     start_mission,
 )
-from shinobi.models import Config, ExecutionResult, VerificationCommandResult
+from shinobi.models import Config, ExecutionResult, MissionSummary, State, VerificationCommandResult
 from shinobi.state_store import StateStore
 
 
@@ -137,7 +137,204 @@ class CliTest(unittest.TestCase):
             self.assertEqual(exit_code, 0)
             rendered = output.getvalue()
             self.assertIn("repo: owner/repo", rendered)
-            self.assertIn("github_status: unavailable in foundations MVP", rendered)
+            self.assertIn("github_status: no active or recent mission to reconcile", rendered)
+
+    def test_status_reconciles_active_mission_with_github(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            issue_number=33,
+                            pr_number=44,
+                            branch="feature/issue-33-status-github-reconciliation",
+                            agent_identity=config.agent_identity,
+                            run_id="run-123",
+                            phase="publish",
+                        )
+                    )
+
+                    client = Mock()
+                    client.get_issue.return_value = {
+                        "number": 33,
+                        "state": "OPEN",
+                        "labels": [
+                            {"name": "priority:medium"},
+                            {"name": "shinobi:reviewing"},
+                        ],
+                    }
+                    client.get_pull_request.return_value = {
+                        "number": 44,
+                        "url": "https://github.com/owner/repo/pull/44",
+                        "isDraft": True,
+                        "headRefName": "feature/issue-33-status-github-reconciliation",
+                        "baseRefName": "main",
+                    }
+
+                    output = io.StringIO()
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
+                        with redirect_stdout(output):
+                            exit_code = cli.main(["status"])
+
+            self.assertEqual(exit_code, 0)
+            rendered = output.getvalue()
+            self.assertIn("github_status_target: active", rendered)
+            self.assertIn("github_issue_state: OPEN", rendered)
+            self.assertIn("github_issue_labels: priority:medium, shinobi:reviewing", rendered)
+            self.assertIn("github_pr_state: draft", rendered)
+            self.assertIn("github_pr_head: feature/issue-33-status-github-reconciliation", rendered)
+
+    def test_status_warns_on_github_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            issue_number=33,
+                            pr_number=44,
+                            branch="feature/issue-33-status-github-reconciliation",
+                            agent_identity=config.agent_identity,
+                            run_id="run-123",
+                            phase="publish",
+                        )
+                    )
+
+                    client = Mock()
+                    client.get_issue.return_value = {
+                        "number": 33,
+                        "state": "OPEN",
+                        "labels": [{"name": "priority:medium"}],
+                    }
+                    client.get_pull_request.return_value = {
+                        "number": 44,
+                        "url": "https://github.com/owner/repo/pull/44",
+                        "isDraft": False,
+                        "headRefName": "feature/unexpected-head",
+                        "baseRefName": "develop",
+                    }
+
+                    output = io.StringIO()
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
+                        with redirect_stdout(output):
+                            exit_code = cli.main(["status"])
+
+            self.assertEqual(exit_code, 0)
+            rendered = output.getvalue()
+            self.assertIn(
+                "warning: issue #33 is missing expected label shinobi:reviewing for phase publish",
+                rendered,
+            )
+            self.assertIn(
+                "warning: local branch feature/issue-33-status-github-reconciliation "
+                "does not match GitHub PR head feature/unexpected-head",
+                rendered,
+            )
+            self.assertIn(
+                "warning: GitHub PR base branch develop does not match configured main branch main",
+                rendered,
+            )
+
+    def test_status_uses_last_mission_when_idle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            agent_identity=config.agent_identity,
+                            phase="idle",
+                            last_mission=MissionSummary(
+                                issue_number=31,
+                                pr_number=44,
+                                branch="feature/issue-31-publish-phase",
+                                phase="publish",
+                                conclusion="needs-human",
+                            ),
+                        )
+                    )
+
+                    client = Mock()
+                    client.get_issue.return_value = {
+                        "number": 31,
+                        "state": "OPEN",
+                        "labels": [{"name": "shinobi:needs-human"}],
+                    }
+                    client.get_pull_request.return_value = {
+                        "number": 44,
+                        "url": "https://github.com/owner/repo/pull/44",
+                        "isDraft": False,
+                        "headRefName": "feature/issue-31-publish-phase",
+                        "baseRefName": "main",
+                    }
+
+                    output = io.StringIO()
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
+                        with redirect_stdout(output):
+                            exit_code = cli.main(["status"])
+
+            self.assertEqual(exit_code, 0)
+            rendered = output.getvalue()
+            self.assertIn("last_mission_issue_number: 31", rendered)
+            self.assertIn("last_mission_conclusion: needs-human", rendered)
+            self.assertIn("github_status_target: last_mission", rendered)
+            self.assertIn("github_pr_number: 44", rendered)
+
+    def test_status_warns_when_github_reconciliation_fails_but_keeps_local_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            issue_number=33,
+                            pr_number=44,
+                            branch="feature/issue-33-status-github-reconciliation",
+                            agent_identity=config.agent_identity,
+                            run_id="run-123",
+                            phase="publish",
+                        )
+                    )
+
+                    client = Mock()
+                    client.get_issue.side_effect = GitHubClientError("boom issue")
+                    client.get_pull_request.side_effect = GitHubClientError("boom pr")
+
+                    output = io.StringIO()
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
+                        with redirect_stdout(output):
+                            exit_code = cli.main(["status"])
+
+            self.assertEqual(exit_code, 0)
+            rendered = output.getvalue()
+            self.assertIn("phase: publish", rendered)
+            self.assertIn("warning: failed to load issue #33: boom issue", rendered)
+            self.assertIn("warning: failed to load PR #44: boom pr", rendered)
 
     def test_status_does_not_recreate_missing_support_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary
- add GitHub reconciliation output to `shinobi status` for active and last missions
- warn on issue label / PR branch mismatches while keeping local status output available
- cover the new status flows with CLI tests and update the README status summary

## Testing
- python3 -m unittest tests.test_cli
- env PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m compileall src tests

## Notes
- Refs #33
