### PR TITLE
Add review stop decision evaluator

### DIFF
--- a/src/shinobi/models.py
+++ b/src/shinobi/models.py
@@ -179,3 +179,24 @@ class ExecutionResult:
     @property
     def succeeded(self) -> bool:
         return all(command.succeeded for command in self.commands)
+
+
+@dataclass(frozen=True)
+class DiffStats:
+    changed_files: int
+    added_lines: int
+    deleted_lines: int
+
+    @property
+    def total_changed_lines(self) -> int:
+        return self.added_lines + self.deleted_lines
+
+
+@dataclass(frozen=True)
+class ReviewDecision:
+    should_stop: bool
+    reasons: List[str]
+
+    @property
+    def can_continue(self) -> bool:
+        return not self.should_stop

--- a/src/shinobi/reviewer.py
+++ b/src/shinobi/reviewer.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .models import Config, DiffStats, ReviewDecision, State
+
+
+class ReviewerError(RuntimeError):
+    """Raised when review inputs cannot be gathered safely."""
+
+
+def collect_diff_stats(root: Path, *, base_ref: str) -> DiffStats:
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--numstat", f"{base_ref}...HEAD"],
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as error:
+        raise ReviewerError(f"failed to collect diff stats against {base_ref}: {error}") from error
+
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or f"git exited with {result.returncode}"
+        raise ReviewerError(f"failed to collect diff stats against {base_ref}: {message}")
+
+    return parse_numstat(result.stdout)
+
+
+def parse_numstat(output: str) -> DiffStats:
+    changed_files = 0
+    added_lines = 0
+    deleted_lines = 0
+
+    for raw_line in output.splitlines():
+        if not raw_line.strip():
+            continue
+        added, deleted, _path = raw_line.split("\t", 2)
+        changed_files += 1
+        if added.isdigit():
+            added_lines += int(added)
+        if deleted.isdigit():
+            deleted_lines += int(deleted)
+
+    return DiffStats(
+        changed_files=changed_files,
+        added_lines=added_lines,
+        deleted_lines=deleted_lines,
+    )
+
+
+def evaluate_review(
+    *,
+    config: Config,
+    state: State,
+    issue: dict[str, Any],
+    diff_stats: DiffStats,
+) -> ReviewDecision:
+    reasons: list[str] = []
+    label_names = issue_label_names(issue)
+    risky_label = config.labels["risky"]
+
+    if risky_label in label_names:
+        reasons.append(
+            f"issue #{issue['number']} has label {risky_label}, requiring human review"
+        )
+
+    if diff_stats.changed_files > config.max_changed_files:
+        reasons.append(
+            "changed files "
+            f"{diff_stats.changed_files} exceed max_changed_files {config.max_changed_files}"
+        )
+
+    if diff_stats.total_changed_lines > config.max_lines_changed:
+        reasons.append(
+            "total changed lines "
+            f"{diff_stats.total_changed_lines} exceed max_lines_changed {config.max_lines_changed}"
+        )
+
+    if state.review_loop_count >= config.max_review_loops:
+        reasons.append(
+            "review loop count "
+            f"{state.review_loop_count} reached max_review_loops {config.max_review_loops}"
+        )
+
+    return ReviewDecision(should_stop=bool(reasons), reasons=reasons)
+
+
+def issue_label_names(issue: dict[str, Any]) -> set[str]:
+    return {
+        label.get("name", "")
+        for label in issue.get("labels", [])
+        if isinstance(label, dict)
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,7 +40,16 @@ from shinobi.mission_start import (
     handoff_started_mission,
     start_mission,
 )
-from shinobi.models import Config, ExecutionResult, MissionSummary, State, VerificationCommandResult
+from shinobi.models import (
+    Config,
+    DiffStats,
+    ExecutionResult,
+    MissionSummary,
+    ReviewDecision,
+    State,
+    VerificationCommandResult,
+)
+from shinobi.reviewer import ReviewerError, collect_diff_stats, evaluate_review, parse_numstat
 from shinobi.state_store import StateStore
 
 
@@ -4472,6 +4481,73 @@ assert (workspace / ".shinobi" / "templates" / "review-note-rule.md").exists()
             )
             self.assertEqual(repaired_state["branch"], "feature/test")
             self.assertEqual(repaired_state["future_field"], {"enabled": True})
+
+
+class ReviewerTest(unittest.TestCase):
+    def test_parse_numstat_counts_changed_files_and_lines(self) -> None:
+        stats = parse_numstat("12\t3\tsrc/shinobi/reviewer.py\n-\t-\tassets/logo.png\n")
+
+        self.assertEqual(
+            stats,
+            DiffStats(
+                changed_files=2,
+                added_lines=12,
+                deleted_lines=3,
+            ),
+        )
+        self.assertEqual(stats.total_changed_lines, 15)
+
+    def test_collect_diff_stats_wraps_git_failures(self) -> None:
+        with patch(
+            "shinobi.reviewer.subprocess.run",
+            return_value=Mock(returncode=1, stdout="", stderr="unknown revision"),
+        ):
+            with self.assertRaisesRegex(
+                ReviewerError,
+                "failed to collect diff stats against origin/main: unknown revision",
+            ):
+                collect_diff_stats(Path("/tmp/repo"), base_ref="origin/main")
+
+    def test_evaluate_review_allows_safe_diff(self) -> None:
+        decision = evaluate_review(
+            config=Config(repo="owner/repo"),
+            state=State(review_loop_count=1),
+            issue={"number": 34, "labels": [{"name": "priority:medium"}]},
+            diff_stats=DiffStats(changed_files=3, added_lines=20, deleted_lines=5),
+        )
+
+        self.assertEqual(decision, ReviewDecision(should_stop=False, reasons=[]))
+        self.assertTrue(decision.can_continue)
+
+    def test_evaluate_review_stops_for_risky_label_and_size_limits(self) -> None:
+        config = Config(
+            repo="owner/repo",
+            max_changed_files=5,
+            max_lines_changed=20,
+            max_review_loops=2,
+        )
+
+        decision = evaluate_review(
+            config=config,
+            state=State(review_loop_count=2),
+            issue={
+                "number": 34,
+                "labels": [{"name": "shinobi:risky"}],
+            },
+            diff_stats=DiffStats(changed_files=6, added_lines=12, deleted_lines=15),
+        )
+
+        self.assertTrue(decision.should_stop)
+        self.assertFalse(decision.can_continue)
+        self.assertEqual(
+            decision.reasons,
+            [
+                "issue #34 has label shinobi:risky, requiring human review",
+                "changed files 6 exceed max_changed_files 5",
+                "total changed lines 27 exceed max_lines_changed 20",
+                "review loop count 2 reached max_review_loops 2",
+            ],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add reviewer-side diff stat collection and stop decision evaluation
- model diff stats and review decisions for reuse in later review phase wiring
- cover safe, risky, and threshold-exceeded review decisions with tests

## Testing
- python3 -m unittest tests.test_cli.ReviewerTest
- env PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m compileall src tests
- python3 -m unittest tests.test_cli

Closes #34
