### PR TITLE
Add pre-publish high-risk stop handling

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,6 +133,7 @@ publish phase は start 済み mission を draft PR として公開します。
 - owner run の lock を確認してから publish する
 - 検証結果に `failed` または `error` が含まれる場合は push / PR 更新前に停止し、`needs-human` へ handoff する
 - 現在の Issue label に `shinobi:blocked` または `shinobi:needs-human` があれば push / PR 更新前に停止する
+- execute 後の差分に config の `high_risk_paths` 配下が含まれる場合は push / PR 更新前に停止し、`needs-human` へ handoff する
 - active branch を `origin` へ push する
 - branch に対応する既存 PR があれば更新し、なければ draft PR を作成する
 - `shinobi:reviewing` を付与し、`shinobi:risky` 以外の状態 label を正規化する

--- a/docs/mvp-design.md
+++ b/docs/mvp-design.md
@@ -215,9 +215,8 @@ fatal 時の補償動作:
 
 - 対象ファイルだけ編集する
 - high-risk path 候補に実際に触れる必要があるかを、publish 前に最終判定する
-- publish 前に high-risk path が確定した場合でも、human handoff に必要な差分があるなら branch を push し、原則 draft PR を作成または更新してから `needs-human` または `blocked` に遷移する
-- この pre-publish stop で PR を作成または更新した場合も、machine-readable な mission-state コメントを同じ mission の comment 上で upsert し、最新の `pr`, `phase`, `lease_expires_at` を反映して recovery と整合させる
-- publish 前に差分が無いか共有価値が無い場合だけ、PR を作らず停止する
+- publish 前に high-risk path が確定した場合は、現行実装では push / PR 作成前に停止して `needs-human` へ handoff する
+- high-risk path 停止で PR を残したまま handoff する挙動は将来拡張として扱う
 - execute 中は `mission_heartbeat_interval_minutes` ごとに定期 heartbeat を更新する
 - 長時間処理に入る前と各 retry 後にも即時 heartbeat を更新する
 - lint / typecheck / test を実行する
@@ -496,7 +495,7 @@ MVP の重要点は「必要最小限しか読まない」ことです。
 
 Shinobi 関連ログは自由文検索ではなく、HTML comment marker の中に固定 schema の key-value block を持つ machine-readable comment を前提にします。最低でも `issue`, `branch`, `phase`, `lease_expires_at`, `pr`, `agent_identity`, `run_id` を含めます。recovery は自由文本文ではなく marker 内 block だけを parse 対象にします。`agent_identity` は `init` が生成する workspace / installation ごとの一意 ID で、複数 runner 間で共有しません。
 
-同じ mission については、開始時に新規作成した mission-state コメントを publish / review / recovery 時に upsert して使い回します。high-risk path などで publish 前に停止する場合でも、PR を作成または更新したなら同じ comment を upsert して `pr` と停止時の phase を最新化します。stale recovery は最新の mission-state comment の marker 内 block の値を truth 候補として参照します。`pr: null` は start から publish 前までの mission に限って許容し、その場合は branch 実体と phase 整合を追加で確認します。publish 済みのはずなのに古い phase や `pr: null` のまま放置されたコメントは resume 根拠に使いません。`agent_identity` が現在設定の一意な `agent_identity` と一致しないコメントは ownership 不一致として resume 根拠から除外します。
+同じ mission については、開始時に新規作成した mission-state コメントを publish / review / recovery 時に upsert して使い回します。現行実装の high-risk path 停止は publish 前 handoff なので、comment は start phase のまま `pr: null` を維持します。stale recovery は最新の mission-state comment の marker 内 block の値を truth 候補として参照します。`pr: null` は start から publish 前までの mission に限って許容し、その場合は branch 実体と phase 整合を追加で確認します。publish 済みのはずなのに古い phase や `pr: null` のまま放置されたコメントは resume 根拠に使いません。`agent_identity` が現在設定の一意な `agent_identity` と一致しないコメントは ownership 不一致として resume 根拠から除外します。
 
 出力:
 
@@ -552,7 +551,7 @@ MVP では次の 2 種類を分けて扱います。
 - `shinobi:risky`: Issue-level の manual merge 指示。publish までは進めるが auto-merge はしない
 - high-risk path: execution risk。対象ファイルが `migrations/` `infra/` `auth/` `billing/` などに触れる必要があるなら publish 前でも停止しうる
 
-high-risk path の一次判定は context で候補抽出し、最終判定は execute 完了前に行います。publish 前に確定した場合でも、human handoff に必要な差分があるなら branch を push し、原則 draft PR を作成または更新したうえで `needs-human` か `blocked` に遷移します。差分が無いか共有価値が無い場合だけ PR 未作成で停止します。publish 後の review で追加検知した場合は PR を残したまま `needs-human` に遷移します。
+high-risk path の一次判定は context で候補抽出し、最終判定は execute 完了後の pre-publish stop で行います。現行実装では publish 前に確定した時点で push / PR 作成前に停止し、start-phase mission を `needs-human` に遷移します。publish 後の review で追加検知した場合は PR を残したまま `needs-human` に遷移します。差分共有のために PR を残したまま handoff する挙動は将来拡張とします。
 
 ### high-risk path 例
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -354,7 +354,7 @@ max_token_budget: 40000
 
 迷ったら自動マージしません。
 
-high-risk path は context で候補抽出し、execute 完了前に publish 可否を最終判定します。publish 前に確定した場合でも、human handoff に必要な差分があるなら branch を push し、原則 draft PR を作成または更新してから `shinobi:needs-human` か `shinobi:blocked` へ遷移します。この pre-publish stop で PR を作成または更新した場合も、machine-readable な mission-state comment は同じ mission の comment を upsert し、最新の `pr`, `phase`, `lease_expires_at` を反映して recovery と整合させます。差分が無いか共有価値が無い場合だけ PR を作らず停止します。publish 後に review で追加検知した場合は PR を残したまま `shinobi:needs-human` へ遷移します。
+high-risk path は context で候補抽出し、execute 完了後の pre-publish stop で publish 可否を最終判定します。現行実装では publish 前に high-risk path が確定した時点で push / PR 作成前に停止し、start-phase mission を `shinobi:needs-human` へ handoff します。publish 後に review で追加検知した場合は PR を残したまま `shinobi:needs-human` へ遷移します。差分共有のために PR を残したまま handoff する挙動は将来拡張として扱います。
 
 publish 直前に現在の Issue がすでに `shinobi:blocked` または `shinobi:needs-human` を持つ場合は、人手の停止判断を優先し、push / PR 作成前に publish を中止します。
 
@@ -440,7 +440,7 @@ Shinobi Start
 
 開始・recovery 用の Shinobi コメントは、自由文に埋もれた箇条書きではなく、HTML comment marker の中に固定 schema の key-value block を置きます。最低キーは `issue`, `branch`, `phase`, `lease_expires_at`, `pr`, `agent_identity`, `run_id` です。自由文本文は人間向けでよいですが、recovery は marker 内の block だけを parse 対象にします。`agent_identity` は `init` が生成する workspace / installation ごとの一意 ID で、複数 runner 間で共有しません。
 
-同じ mission では、この comment を publish / review / recovery のたびに upsert し、marker 内の `phase` `pr` `lease_expires_at` を最新値へ更新します。high-risk path などで publish 前に停止する場合でも、PR を作成または更新したなら同じ comment を upsert して `pr` と停止時の phase を最新化します。stale recovery は最新の machine-readable block と local / PR metadata が整合し、`agent_identity` も現在設定の一意な `agent_identity` と一致する場合だけ行います。publish 前の mission では `pr: null` を許容しますが、その場合は branch 実体と pre-publish phase の整合確認を必須にします。
+同じ mission では、この comment を publish / review / recovery のたびに upsert し、marker 内の `phase` `pr` `lease_expires_at` を最新値へ更新します。現行実装の high-risk path 停止は publish 前 handoff なので、machine-readable な mission-state comment は start phase のまま `pr: null` を維持します。stale recovery は最新の machine-readable block と local / PR metadata が整合し、`agent_identity` も現在設定の一意な `agent_identity` と一致する場合だけ行います。publish 前の mission では `pr: null` を許容しますが、その場合は branch 実体と pre-publish phase の整合確認を必須にします。
 
 レビュー中:
 

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -20,7 +20,9 @@ from .issue_selector import (
 )
 from .mission_publish import (
     MissionPublishError,
+    PublishedMission,
     blocking_verification_results,
+    handoff_published_mission,
     publish_mission,
 )
 from .mission_start import (
@@ -430,14 +432,6 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
                 execution_result=execution_result,
             )
             stop_decision = detect_high_risk_stop(root, config)
-            handoff_pre_publish_stop(
-                root=root,
-                store=store,
-                config=config,
-                run_id=run_id,
-                started_mission=started_mission,
-                stop_decision=stop_decision,
-            )
             published_mission = publish_mission(
                 root=root,
                 store=store,
@@ -445,6 +439,15 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
                 run_id=run_id,
                 state=store.load_state(),
                 execution_result=execution_result,
+            )
+            handoff_pre_publish_stop(
+                root=root,
+                store=store,
+                config=config,
+                run_id=run_id,
+                started_mission=started_mission,
+                stop_decision=stop_decision,
+                published_mission=published_mission,
             )
         except (MissionStartError, MissionPublishError, RuntimeError, ValueError) as error:
             print(f"run aborted: {error}")
@@ -532,6 +535,7 @@ def handoff_pre_publish_stop(
     run_id: str,
     started_mission: StartedMission,
     stop_decision: StopDecision | None,
+    published_mission: PublishedMission | None = None,
 ) -> None:
     if stop_decision is None:
         return
@@ -542,14 +546,24 @@ def handoff_pre_publish_stop(
             f"{stop_decision.conclusion}"
         )
 
-    handoff_started_mission(
-        root=root,
-        store=store,
-        config=config,
-        run_id=run_id,
-        started_mission=started_mission,
-        reason=stop_decision.reason,
-    )
+    if published_mission is None:
+        handoff_started_mission(
+            root=root,
+            store=store,
+            config=config,
+            run_id=run_id,
+            started_mission=started_mission,
+            reason=stop_decision.reason,
+        )
+    else:
+        handoff_published_mission(
+            root=root,
+            store=store,
+            config=config,
+            run_id=run_id,
+            published_mission=published_mission,
+            reason=stop_decision.reason,
+        )
     raise MissionPublishError(stop_decision.reason)
 
 

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, List, Optional
 
 from .config import discover_workspace_root
-from .executor import execute_verification
+from .executor import detect_high_risk_stop, execute_verification
 from .github_client import GitHubClient, GitHubClientError
 from .issue_selector import (
     ensure_open_issue,
@@ -29,7 +29,7 @@ from .mission_start import (
     handoff_started_mission,
     start_mission,
 )
-from .models import Config, ExecutionResult, State
+from .models import Config, ExecutionResult, State, StopDecision
 from .state_store import StateStore
 
 
@@ -429,6 +429,15 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
                 started_mission=started_mission,
                 execution_result=execution_result,
             )
+            stop_decision = detect_high_risk_stop(root, config)
+            handoff_pre_publish_stop(
+                root=root,
+                store=store,
+                config=config,
+                run_id=run_id,
+                started_mission=started_mission,
+                stop_decision=stop_decision,
+            )
             published_mission = publish_mission(
                 root=root,
                 store=store,
@@ -513,6 +522,35 @@ def handoff_failed_verification(
         reason=reason,
     )
     raise MissionPublishError(reason)
+
+
+def handoff_pre_publish_stop(
+    *,
+    root: Path,
+    store: StateStore,
+    config: Config,
+    run_id: str,
+    started_mission: StartedMission,
+    stop_decision: StopDecision | None,
+) -> None:
+    if stop_decision is None:
+        return
+
+    if stop_decision.conclusion != "needs-human":
+        raise MissionPublishError(
+            "pre-publish stop currently supports only needs-human handoff, got "
+            f"{stop_decision.conclusion}"
+        )
+
+    handoff_started_mission(
+        root=root,
+        store=store,
+        config=config,
+        run_id=run_id,
+        started_mission=started_mission,
+        reason=stop_decision.reason,
+    )
+    raise MissionPublishError(stop_decision.reason)
 
 
 def main(argv: Optional[List[str]] = None) -> int:

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -21,7 +21,10 @@ from .issue_selector import (
 from .mission_publish import (
     MissionPublishError,
     blocking_verification_results,
+    find_blocking_publish_labels,
+    load_publishable_issue_label_names,
     publish_mission,
+    stop_publish_for_blocking_labels,
 )
 from .mission_start import (
     MissionStartError,
@@ -538,8 +541,28 @@ def detect_pre_publish_stop(
     run_id: str,
     started_mission: StartedMission,
 ) -> StopDecision | None:
+    client = GitHubClient(root, repo=config.repo)
     try:
+        issue_label_names = load_publishable_issue_label_names(
+            client=client,
+            issue_number=started_mission.issue_number,
+        )
+        blocking_labels = find_blocking_publish_labels(
+            label_names=issue_label_names,
+            config=config,
+        )
+        if blocking_labels:
+            stop_publish_for_blocking_labels(
+                store=store,
+                issue_number=started_mission.issue_number,
+                branch=started_mission.branch,
+                agent_identity=config.agent_identity,
+                blocking_labels=blocking_labels,
+                blocked_label=config.labels["blocked"],
+            )
         return detect_high_risk_stop(root, config)
+    except MissionPublishError:
+        raise
     except RuntimeError as error:
         reason = f"Shinobi failed to evaluate pre-publish stop conditions: {error}"
         handoff_started_mission(

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -20,7 +20,9 @@ from .issue_selector import (
 )
 from .mission_publish import (
     MissionPublishError,
+    PublishedMission,
     blocking_verification_results,
+    handoff_published_mission,
     publish_mission,
 )
 from .mission_start import (
@@ -436,14 +438,6 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
                 run_id=run_id,
                 started_mission=started_mission,
             )
-            handoff_pre_publish_stop(
-                root=root,
-                store=store,
-                config=config,
-                run_id=run_id,
-                started_mission=started_mission,
-                stop_decision=stop_decision,
-            )
             published_mission = publish_mission(
                 root=root,
                 store=store,
@@ -451,6 +445,14 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
                 run_id=run_id,
                 state=store.load_state(),
                 execution_result=execution_result,
+            )
+            handoff_pre_publish_stop(
+                root=root,
+                store=store,
+                config=config,
+                run_id=run_id,
+                published_mission=published_mission,
+                stop_decision=stop_decision,
             )
         except (MissionStartError, MissionPublishError, RuntimeError, ValueError) as error:
             print(f"run aborted: {error}")
@@ -559,7 +561,7 @@ def handoff_pre_publish_stop(
     store: StateStore,
     config: Config,
     run_id: str,
-    started_mission: StartedMission,
+    published_mission: PublishedMission,
     stop_decision: StopDecision | None,
 ) -> None:
     if stop_decision is None:
@@ -571,22 +573,22 @@ def handoff_pre_publish_stop(
             f"{stop_decision.conclusion}; handing off to needs-human instead. "
             f"Original reason: {stop_decision.reason}"
         )
-        handoff_started_mission(
+        handoff_published_mission(
             root=root,
             store=store,
             config=config,
             run_id=run_id,
-            started_mission=started_mission,
+            published_mission=published_mission,
             reason=reason,
         )
         raise MissionPublishError(reason)
 
-    handoff_started_mission(
+    handoff_published_mission(
         root=root,
         store=store,
         config=config,
         run_id=run_id,
-        started_mission=started_mission,
+        published_mission=published_mission,
         reason=stop_decision.reason,
     )
     raise MissionPublishError(stop_decision.reason)

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -20,9 +20,7 @@ from .issue_selector import (
 )
 from .mission_publish import (
     MissionPublishError,
-    PublishedMission,
     blocking_verification_results,
-    handoff_published_mission,
     publish_mission,
 )
 from .mission_start import (
@@ -438,14 +436,6 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
                 run_id=run_id,
                 started_mission=started_mission,
             )
-            published_mission = publish_mission(
-                root=root,
-                store=store,
-                config=config,
-                run_id=run_id,
-                state=store.load_state(),
-                execution_result=execution_result,
-            )
             handoff_pre_publish_stop(
                 root=root,
                 store=store,
@@ -453,7 +443,14 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
                 run_id=run_id,
                 started_mission=started_mission,
                 stop_decision=stop_decision,
-                published_mission=published_mission,
+            )
+            published_mission = publish_mission(
+                root=root,
+                store=store,
+                config=config,
+                run_id=run_id,
+                state=store.load_state(),
+                execution_result=execution_result,
             )
         except (MissionStartError, MissionPublishError, RuntimeError, ValueError) as error:
             print(f"run aborted: {error}")
@@ -564,7 +561,6 @@ def handoff_pre_publish_stop(
     run_id: str,
     started_mission: StartedMission,
     stop_decision: StopDecision | None,
-    published_mission: PublishedMission | None = None,
 ) -> None:
     if stop_decision is None:
         return
@@ -575,24 +571,14 @@ def handoff_pre_publish_stop(
             f"{stop_decision.conclusion}"
         )
 
-    if published_mission is None:
-        handoff_started_mission(
-            root=root,
-            store=store,
-            config=config,
-            run_id=run_id,
-            started_mission=started_mission,
-            reason=stop_decision.reason,
-        )
-    else:
-        handoff_published_mission(
-            root=root,
-            store=store,
-            config=config,
-            run_id=run_id,
-            published_mission=published_mission,
-            reason=stop_decision.reason,
-        )
+    handoff_started_mission(
+        root=root,
+        store=store,
+        config=config,
+        run_id=run_id,
+        started_mission=started_mission,
+        reason=stop_decision.reason,
+    )
     raise MissionPublishError(stop_decision.reason)
 
 

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -431,7 +431,13 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
                 started_mission=started_mission,
                 execution_result=execution_result,
             )
-            stop_decision = detect_high_risk_stop(root, config)
+            stop_decision = detect_pre_publish_stop(
+                root=root,
+                store=store,
+                config=config,
+                run_id=run_id,
+                started_mission=started_mission,
+            )
             published_mission = publish_mission(
                 root=root,
                 store=store,
@@ -525,6 +531,29 @@ def handoff_failed_verification(
         reason=reason,
     )
     raise MissionPublishError(reason)
+
+
+def detect_pre_publish_stop(
+    *,
+    root: Path,
+    store: StateStore,
+    config: Config,
+    run_id: str,
+    started_mission: StartedMission,
+) -> StopDecision | None:
+    try:
+        return detect_high_risk_stop(root, config)
+    except RuntimeError as error:
+        reason = f"Shinobi failed to evaluate pre-publish stop conditions: {error}"
+        handoff_started_mission(
+            root=root,
+            store=store,
+            config=config,
+            run_id=run_id,
+            started_mission=started_mission,
+            reason=reason,
+        )
+        raise MissionPublishError(reason) from error
 
 
 def handoff_pre_publish_stop(

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -566,10 +566,20 @@ def handoff_pre_publish_stop(
         return
 
     if stop_decision.conclusion != "needs-human":
-        raise MissionPublishError(
-            "pre-publish stop currently supports only needs-human handoff, got "
-            f"{stop_decision.conclusion}"
+        reason = (
+            "pre-publish stop requested unsupported conclusion "
+            f"{stop_decision.conclusion}; handing off to needs-human instead. "
+            f"Original reason: {stop_decision.reason}"
         )
+        handoff_started_mission(
+            root=root,
+            store=store,
+            config=config,
+            run_id=run_id,
+            started_mission=started_mission,
+            reason=reason,
+        )
+        raise MissionPublishError(reason)
 
     handoff_started_mission(
         root=root,

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -547,22 +547,34 @@ def detect_pre_publish_stop(
             client=client,
             issue_number=started_mission.issue_number,
         )
-        blocking_labels = find_blocking_publish_labels(
-            label_names=issue_label_names,
+    except MissionPublishError as error:
+        reason = f"Shinobi failed to evaluate pre-publish stop conditions: {error}"
+        handoff_started_mission(
+            root=root,
+            store=store,
             config=config,
+            run_id=run_id,
+            started_mission=started_mission,
+            reason=reason,
         )
-        if blocking_labels:
-            stop_publish_for_blocking_labels(
-                store=store,
-                issue_number=started_mission.issue_number,
-                branch=started_mission.branch,
-                agent_identity=config.agent_identity,
-                blocking_labels=blocking_labels,
-                blocked_label=config.labels["blocked"],
-            )
+        raise MissionPublishError(reason) from error
+
+    blocking_labels = find_blocking_publish_labels(
+        label_names=issue_label_names,
+        config=config,
+    )
+    if blocking_labels:
+        stop_publish_for_blocking_labels(
+            store=store,
+            issue_number=started_mission.issue_number,
+            branch=started_mission.branch,
+            agent_identity=config.agent_identity,
+            blocking_labels=blocking_labels,
+            blocked_label=config.labels["blocked"],
+        )
+
+    try:
         return detect_high_risk_stop(root, config)
-    except MissionPublishError:
-        raise
     except RuntimeError as error:
         reason = f"Shinobi failed to evaluate pre-publish stop conditions: {error}"
         handoff_started_mission(

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -20,9 +20,7 @@ from .issue_selector import (
 )
 from .mission_publish import (
     MissionPublishError,
-    PublishedMission,
     blocking_verification_results,
-    handoff_published_mission,
     publish_mission,
 )
 from .mission_start import (
@@ -438,6 +436,14 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
                 run_id=run_id,
                 started_mission=started_mission,
             )
+            handoff_pre_publish_stop(
+                root=root,
+                store=store,
+                config=config,
+                run_id=run_id,
+                started_mission=started_mission,
+                stop_decision=stop_decision,
+            )
             published_mission = publish_mission(
                 root=root,
                 store=store,
@@ -445,14 +451,6 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
                 run_id=run_id,
                 state=store.load_state(),
                 execution_result=execution_result,
-            )
-            handoff_pre_publish_stop(
-                root=root,
-                store=store,
-                config=config,
-                run_id=run_id,
-                published_mission=published_mission,
-                stop_decision=stop_decision,
             )
         except (MissionStartError, MissionPublishError, RuntimeError, ValueError) as error:
             print(f"run aborted: {error}")
@@ -561,7 +559,7 @@ def handoff_pre_publish_stop(
     store: StateStore,
     config: Config,
     run_id: str,
-    published_mission: PublishedMission,
+    started_mission: StartedMission,
     stop_decision: StopDecision | None,
 ) -> None:
     if stop_decision is None:
@@ -573,22 +571,22 @@ def handoff_pre_publish_stop(
             f"{stop_decision.conclusion}; handing off to needs-human instead. "
             f"Original reason: {stop_decision.reason}"
         )
-        handoff_published_mission(
+        handoff_started_mission(
             root=root,
             store=store,
             config=config,
             run_id=run_id,
-            published_mission=published_mission,
+            started_mission=started_mission,
             reason=reason,
         )
         raise MissionPublishError(reason)
 
-    handoff_published_mission(
+    handoff_started_mission(
         root=root,
         store=store,
         config=config,
         run_id=run_id,
-        published_mission=published_mission,
+        started_mission=started_mission,
         reason=stop_decision.reason,
     )
     raise MissionPublishError(stop_decision.reason)

--- a/src/shinobi/executor.py
+++ b/src/shinobi/executor.py
@@ -81,10 +81,10 @@ def collect_changed_paths(root: Path, *, base_ref: str) -> list[str]:
 
 
 def collect_paths_against_base_ref(root: Path, *, base_ref: str) -> list[str]:
-    candidate_refs = [base_ref]
     remote_candidate = f"origin/{base_ref}"
+    candidate_refs = [remote_candidate]
     if remote_candidate != base_ref:
-        candidate_refs.append(remote_candidate)
+        candidate_refs.append(base_ref)
 
     errors: list[str] = []
     for candidate_ref in candidate_refs:

--- a/src/shinobi/executor.py
+++ b/src/shinobi/executor.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from typing import Iterable
 
-from .models import Config, ExecutionResult, VerificationCommandResult
+from .models import Config, ExecutionResult, StopDecision, VerificationCommandResult
 
 
 VERIFICATION_ORDER = ("lint", "typecheck", "test")
@@ -18,6 +19,76 @@ def execute_verification(root: Path, config: Config) -> ExecutionResult:
         commands=results,
         change_summary="No automated code changes are performed by the minimal executor.",
     )
+
+
+def detect_high_risk_stop(root: Path, config: Config) -> StopDecision | None:
+    changed_paths = collect_changed_paths(root, base_ref=config.main_branch)
+    matched_paths = find_high_risk_paths(
+        changed_paths=changed_paths,
+        high_risk_paths=config.high_risk_paths,
+    )
+    if not matched_paths:
+        return None
+
+    risky_files = sorted(
+        path
+        for path in changed_paths
+        if any(path_matches_high_risk(path, matched_path) for matched_path in matched_paths)
+    )
+    joined_paths = ", ".join(matched_paths)
+    joined_files = ", ".join(risky_files)
+    return StopDecision(
+        reason=(
+            "Shinobi stopped before publish because changed files match "
+            f"high-risk path(s): {joined_paths} (files: {joined_files})"
+        ),
+        conclusion="needs-human",
+        retryable=False,
+        changed_paths=risky_files,
+        matched_paths=matched_paths,
+    )
+
+
+def collect_changed_paths(root: Path, *, base_ref: str) -> list[str]:
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "--diff-filter=ACMR", f"{base_ref}...HEAD"],
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as error:
+        raise RuntimeError(
+            f"failed to collect changed paths against {base_ref}: {error}"
+        ) from error
+
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or f"git exited with {result.returncode}"
+        raise RuntimeError(f"failed to collect changed paths against {base_ref}: {message}")
+
+    return [normalize_repo_path(line) for line in result.stdout.splitlines() if line.strip()]
+
+
+def find_high_risk_paths(*, changed_paths: Iterable[str], high_risk_paths: Iterable[str]) -> list[str]:
+    normalized_high_risk_paths = [normalize_repo_path(path) for path in high_risk_paths if path.strip()]
+    matched = {
+        high_risk_path
+        for high_risk_path in normalized_high_risk_paths
+        if any(path_matches_high_risk(changed_path, high_risk_path) for changed_path in changed_paths)
+    }
+    return sorted(matched)
+
+
+def path_matches_high_risk(changed_path: str, high_risk_path: str) -> bool:
+    if high_risk_path.endswith("/"):
+        return changed_path.startswith(high_risk_path)
+    return changed_path == high_risk_path or changed_path.startswith(f"{high_risk_path}/")
+
+
+def normalize_repo_path(path: str) -> str:
+    normalized = path.replace("\\", "/").lstrip("./")
+    return normalized if not path.endswith("/") else normalized.rstrip("/") + "/"
 
 
 def run_verification_command(

--- a/src/shinobi/executor.py
+++ b/src/shinobi/executor.py
@@ -57,21 +57,21 @@ def collect_changed_paths(root: Path, *, base_ref: str) -> list[str]:
         )
     )
     changed_paths.update(
-        run_changed_paths_command(
+        run_diff_paths_command(
             root,
-            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMRD"],
+            ["git", "diff", "--cached", "--name-status", "--diff-filter=ACMRD"],
             error_context="failed to collect staged changed paths",
         )
     )
     changed_paths.update(
-        run_changed_paths_command(
+        run_diff_paths_command(
             root,
-            ["git", "diff", "--name-only", "--diff-filter=ACMRD"],
+            ["git", "diff", "--name-status", "--diff-filter=ACMRD"],
             error_context="failed to collect unstaged changed paths",
         )
     )
     changed_paths.update(
-        run_changed_paths_command(
+        run_line_paths_command(
             root,
             ["git", "ls-files", "--others", "--exclude-standard"],
             error_context="failed to collect untracked changed paths",
@@ -89,9 +89,9 @@ def collect_paths_against_base_ref(root: Path, *, base_ref: str) -> list[str]:
     errors: list[str] = []
     for candidate_ref in candidate_refs:
         try:
-            return run_changed_paths_command(
+            return run_diff_paths_command(
                 root,
-                ["git", "diff", "--name-only", "--diff-filter=ACMRD", f"{candidate_ref}...HEAD"],
+                ["git", "diff", "--name-status", "--diff-filter=ACMRD", f"{candidate_ref}...HEAD"],
                 error_context=f"failed to collect changed paths against {candidate_ref}",
             )
         except RuntimeError as error:
@@ -110,12 +110,32 @@ def is_missing_revision_error(message: str) -> bool:
     return "unknown revision" in lowered or "bad revision" in lowered
 
 
-def run_changed_paths_command(
+def run_diff_paths_command(
     root: Path,
     command: list[str],
     *,
     error_context: str,
 ) -> list[str]:
+    result = run_git_command(root, command, error_context=error_context)
+    return parse_name_status_paths(result.stdout)
+
+
+def run_line_paths_command(
+    root: Path,
+    command: list[str],
+    *,
+    error_context: str,
+) -> list[str]:
+    result = run_git_command(root, command, error_context=error_context)
+    return [normalize_repo_path(line) for line in result.stdout.splitlines() if line.strip()]
+
+
+def run_git_command(
+    root: Path,
+    command: list[str],
+    *,
+    error_context: str,
+) -> subprocess.CompletedProcess[str]:
     try:
         result = subprocess.run(
             command,
@@ -131,7 +151,24 @@ def run_changed_paths_command(
         message = result.stderr.strip() or result.stdout.strip() or f"git exited with {result.returncode}"
         raise RuntimeError(f"{error_context}: {message}")
 
-    return [normalize_repo_path(line) for line in result.stdout.splitlines() if line.strip()]
+    return result
+
+
+def parse_name_status_paths(output: str) -> list[str]:
+    paths: list[str] = []
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        fields = line.split("\t")
+        status = fields[0]
+        changed_fields = fields[1:]
+        if not status or not changed_fields:
+            continue
+        if status[0] in {"R", "C"}:
+            paths.extend(normalize_repo_path(path) for path in changed_fields if path.strip())
+            continue
+        paths.append(normalize_repo_path(changed_fields[0]))
+    return paths
 
 
 def find_high_risk_paths(*, changed_paths: Iterable[str], high_risk_paths: Iterable[str]) -> list[str]:

--- a/src/shinobi/executor.py
+++ b/src/shinobi/executor.py
@@ -87,7 +87,11 @@ def path_matches_high_risk(changed_path: str, high_risk_path: str) -> bool:
 
 
 def normalize_repo_path(path: str) -> str:
-    normalized = path.replace("\\", "/").lstrip("./")
+    normalized = path.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    while normalized.startswith("/"):
+        normalized = normalized[1:]
     return normalized if not path.endswith("/") else normalized.rstrip("/") + "/"
 
 

--- a/src/shinobi/executor.py
+++ b/src/shinobi/executor.py
@@ -50,22 +50,57 @@ def detect_high_risk_stop(root: Path, config: Config) -> StopDecision | None:
 
 
 def collect_changed_paths(root: Path, *, base_ref: str) -> list[str]:
+    changed_paths = set(
+        run_changed_paths_command(
+            root,
+            ["git", "diff", "--name-only", "--diff-filter=ACMRD", f"{base_ref}...HEAD"],
+            error_context=f"failed to collect changed paths against {base_ref}",
+        )
+    )
+    changed_paths.update(
+        run_changed_paths_command(
+            root,
+            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMRD"],
+            error_context="failed to collect staged changed paths",
+        )
+    )
+    changed_paths.update(
+        run_changed_paths_command(
+            root,
+            ["git", "diff", "--name-only", "--diff-filter=ACMRD"],
+            error_context="failed to collect unstaged changed paths",
+        )
+    )
+    changed_paths.update(
+        run_changed_paths_command(
+            root,
+            ["git", "ls-files", "--others", "--exclude-standard"],
+            error_context="failed to collect untracked changed paths",
+        )
+    )
+    return sorted(changed_paths)
+
+
+def run_changed_paths_command(
+    root: Path,
+    command: list[str],
+    *,
+    error_context: str,
+) -> list[str]:
     try:
         result = subprocess.run(
-            ["git", "diff", "--name-only", "--diff-filter=ACMR", f"{base_ref}...HEAD"],
+            command,
             cwd=root,
             check=False,
             capture_output=True,
             text=True,
         )
     except OSError as error:
-        raise RuntimeError(
-            f"failed to collect changed paths against {base_ref}: {error}"
-        ) from error
+        raise RuntimeError(f"{error_context}: {error}") from error
 
     if result.returncode != 0:
         message = result.stderr.strip() or result.stdout.strip() or f"git exited with {result.returncode}"
-        raise RuntimeError(f"failed to collect changed paths against {base_ref}: {message}")
+        raise RuntimeError(f"{error_context}: {message}")
 
     return [normalize_repo_path(line) for line in result.stdout.splitlines() if line.strip()]
 

--- a/src/shinobi/executor.py
+++ b/src/shinobi/executor.py
@@ -51,10 +51,9 @@ def detect_high_risk_stop(root: Path, config: Config) -> StopDecision | None:
 
 def collect_changed_paths(root: Path, *, base_ref: str) -> list[str]:
     changed_paths = set(
-        run_changed_paths_command(
+        collect_paths_against_base_ref(
             root,
-            ["git", "diff", "--name-only", "--diff-filter=ACMRD", f"{base_ref}...HEAD"],
-            error_context=f"failed to collect changed paths against {base_ref}",
+            base_ref=base_ref,
         )
     )
     changed_paths.update(
@@ -79,6 +78,36 @@ def collect_changed_paths(root: Path, *, base_ref: str) -> list[str]:
         )
     )
     return sorted(changed_paths)
+
+
+def collect_paths_against_base_ref(root: Path, *, base_ref: str) -> list[str]:
+    candidate_refs = [base_ref]
+    remote_candidate = f"origin/{base_ref}"
+    if remote_candidate != base_ref:
+        candidate_refs.append(remote_candidate)
+
+    errors: list[str] = []
+    for candidate_ref in candidate_refs:
+        try:
+            return run_changed_paths_command(
+                root,
+                ["git", "diff", "--name-only", "--diff-filter=ACMRD", f"{candidate_ref}...HEAD"],
+                error_context=f"failed to collect changed paths against {candidate_ref}",
+            )
+        except RuntimeError as error:
+            error_message = str(error)
+            if not is_missing_revision_error(error_message) or candidate_ref == candidate_refs[-1]:
+                errors.append(error_message)
+                break
+            errors.append(error_message)
+
+    joined_errors = "; ".join(errors)
+    raise RuntimeError(joined_errors)
+
+
+def is_missing_revision_error(message: str) -> bool:
+    lowered = message.lower()
+    return "unknown revision" in lowered or "bad revision" in lowered
 
 
 def run_changed_paths_command(

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -259,6 +259,54 @@ def publish_mission(
     )
 
 
+def handoff_published_mission(
+    *,
+    root: Path,
+    store: StateStore,
+    config: Config,
+    run_id: str,
+    published_mission: PublishedMission,
+    reason: str,
+) -> None:
+    client = GitHubClient(root, repo=config.repo)
+    known_label_names = load_handoff_label_names(
+        client=client,
+        issue_number=published_mission.issue_number,
+        fallback_label_names={config.labels["reviewing"]},
+    )
+    rollback_error = transition_publish_failure_to_needs_human(
+        client=client,
+        issue_number=published_mission.issue_number,
+        config=config,
+        reason=reason,
+        known_label_names=known_label_names,
+        lease_expires_at=published_mission.lease_expires_at,
+        agent_identity=config.agent_identity,
+        run_id=run_id,
+        pr_number=published_mission.pr_number,
+        branch=published_mission.branch,
+    )
+    state_error = None
+    if rollback_error is None:
+        state_error = save_publish_handoff_state(
+            store=store,
+            issue_number=published_mission.issue_number,
+            pr_number=published_mission.pr_number,
+            branch=published_mission.branch,
+            agent_identity=config.agent_identity,
+            reason=reason,
+        )
+
+    if rollback_error is not None:
+        raise MissionPublishError(
+            f"{reason}; failed to hand off published mission: {rollback_error}"
+        )
+    if state_error is not None:
+        raise MissionPublishError(
+            f"{reason}; failed to persist published mission handoff state: {state_error}"
+        )
+
+
 def require_publishable_state(
     state: State,
     *,

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -258,55 +258,6 @@ def publish_mission(
         pr_url=pr_url,
     )
 
-
-def handoff_published_mission(
-    *,
-    root: Path,
-    store: StateStore,
-    config: Config,
-    run_id: str,
-    published_mission: PublishedMission,
-    reason: str,
-) -> None:
-    client = GitHubClient(root, repo=config.repo)
-    known_label_names = load_handoff_label_names(
-        client=client,
-        issue_number=published_mission.issue_number,
-        fallback_label_names={config.labels["reviewing"]},
-    )
-    rollback_error = transition_publish_failure_to_needs_human(
-        client=client,
-        issue_number=published_mission.issue_number,
-        config=config,
-        reason=reason,
-        known_label_names=known_label_names,
-        lease_expires_at=published_mission.lease_expires_at,
-        agent_identity=config.agent_identity,
-        run_id=run_id,
-        pr_number=published_mission.pr_number,
-        branch=published_mission.branch,
-    )
-    state_error = None
-    if rollback_error is None:
-        state_error = save_publish_handoff_state(
-            store=store,
-            issue_number=published_mission.issue_number,
-            pr_number=published_mission.pr_number,
-            branch=published_mission.branch,
-            agent_identity=config.agent_identity,
-            reason=reason,
-        )
-
-    if rollback_error is not None:
-        raise MissionPublishError(
-            f"{reason}; failed to hand off published mission: {rollback_error}"
-        )
-    if state_error is not None:
-        raise MissionPublishError(
-            f"{reason}; failed to persist published mission handoff state: {state_error}"
-        )
-
-
 def require_publishable_state(
     state: State,
     *,

--- a/src/shinobi/models.py
+++ b/src/shinobi/models.py
@@ -182,6 +182,15 @@ class ExecutionResult:
 
 
 @dataclass(frozen=True)
+class StopDecision:
+    reason: str
+    conclusion: str
+    retryable: bool = False
+    changed_paths: List[str] = field(default_factory=list)
+    matched_paths: List[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
 class DiffStats:
     changed_files: int
     added_lines: int

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -987,6 +987,73 @@ class CliTest(unittest.TestCase):
             publish_mock.assert_called_once()
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
+    def test_run_hands_off_when_high_risk_detection_fails_before_publish(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    output = io.StringIO()
+                    started_mission = Mock(
+                        branch="feature/issue-6-run-start-phase",
+                        issue_number=6,
+                        lease_expires_at="2026-04-09T00:30:00Z",
+                    )
+                    execution_result = ExecutionResult(
+                        commands=[
+                            VerificationCommandResult(
+                                name="test",
+                                command=["python3", "-m", "unittest"],
+                                status="passed",
+                                returncode=0,
+                            )
+                        ],
+                        change_summary="Changed auth flow.",
+                    )
+                    with patch("shinobi.cli.list_open_issues_with_any_label", return_value=[]):
+                        with patch("shinobi.cli.select_ready_issue", return_value=6):
+                            with patch(
+                                "shinobi.cli.load_issue",
+                                return_value={"number": 6, "title": "Run start phase"},
+                            ):
+                                with patch(
+                                    "shinobi.cli.start_mission",
+                                    return_value=started_mission,
+                                ):
+                                    with patch(
+                                        "shinobi.cli.execute_verification",
+                                        return_value=execution_result,
+                                    ):
+                                        with patch(
+                                            "shinobi.cli.detect_high_risk_stop",
+                                            side_effect=RuntimeError("unknown revision"),
+                                        ):
+                                            with patch(
+                                                "shinobi.cli.handoff_started_mission"
+                                            ) as handoff_mock:
+                                                with patch(
+                                                    "shinobi.cli.publish_mission"
+                                                ) as publish_mock:
+                                                    with redirect_stdout(output):
+                                                        exit_code = cli.main(["run"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn(
+                "run aborted: Shinobi failed to evaluate pre-publish stop conditions: "
+                "unknown revision",
+                output.getvalue(),
+            )
+            handoff_mock.assert_called_once()
+            self.assertEqual(
+                handoff_mock.call_args.kwargs["reason"],
+                "Shinobi failed to evaluate pre-publish stop conditions: unknown revision",
+            )
+            publish_mock.assert_not_called()
+            self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
+
     def test_run_refuses_active_github_mission_before_selecting_ready_issue(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from shinobi import cli
 from shinobi.config import discover_repo_slug
 from shinobi.context_builder import build_mission_context
-from shinobi.executor import execute_verification, run_verification_command
+from shinobi.executor import (
+    collect_changed_paths,
+    detect_high_risk_stop,
+    execute_verification,
+    find_high_risk_paths,
+    run_verification_command,
+)
 from shinobi.github_client import GitHubClient, GitHubClientError
 from shinobi.mission_finalize import (
     MissionFinalizeError,
@@ -46,6 +52,7 @@ from shinobi.models import (
     ExecutionResult,
     MissionSummary,
     ReviewDecision,
+    StopDecision,
     State,
     VerificationCommandResult,
 )
@@ -814,15 +821,19 @@ class CliTest(unittest.TestCase):
                                         return_value=execution_result,
                                     ):
                                         with patch(
-                                            "shinobi.cli.publish_mission",
-                                            return_value=Mock(
-                                                pr_number=31,
-                                                pr_url="https://github.com/owner/repo/pull/31",
-                                                lease_expires_at="2026-04-09T00:30:00Z",
-                                            ),
-                                        ) as publish_mock:
-                                            with redirect_stdout(output):
-                                                exit_code = cli.main(["run"])
+                                            "shinobi.cli.detect_high_risk_stop",
+                                            return_value=None,
+                                        ):
+                                            with patch(
+                                                "shinobi.cli.publish_mission",
+                                                return_value=Mock(
+                                                    pr_number=31,
+                                                    pr_url="https://github.com/owner/repo/pull/31",
+                                                    lease_expires_at="2026-04-09T00:30:00Z",
+                                                ),
+                                            ) as publish_mock:
+                                                with redirect_stdout(output):
+                                                    exit_code = cli.main(["run"])
 
             self.assertEqual(exit_code, 0)
             rendered = output.getvalue()
@@ -890,6 +901,82 @@ class CliTest(unittest.TestCase):
             )
             handoff_mock.assert_called_once()
             self.assertIn("test: failed", handoff_mock.call_args.kwargs["reason"])
+            publish_mock.assert_not_called()
+            self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
+
+    def test_run_hands_off_when_high_risk_paths_are_detected_before_publish(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    output = io.StringIO()
+                    started_mission = Mock(
+                        branch="feature/issue-6-run-start-phase",
+                        issue_number=6,
+                        lease_expires_at="2026-04-09T00:30:00Z",
+                    )
+                    execution_result = ExecutionResult(
+                        commands=[
+                            VerificationCommandResult(
+                                name="test",
+                                command=["python3", "-m", "unittest"],
+                                status="passed",
+                                returncode=0,
+                            )
+                        ],
+                        change_summary="Changed auth flow.",
+                    )
+                    stop_decision = StopDecision(
+                        reason=(
+                            "Shinobi stopped before publish because changed files match "
+                            "high-risk path(s): auth/ (files: auth/login.py)"
+                        ),
+                        conclusion="needs-human",
+                        changed_paths=["auth/login.py"],
+                        matched_paths=["auth/"],
+                    )
+                    with patch("shinobi.cli.list_open_issues_with_any_label", return_value=[]):
+                        with patch("shinobi.cli.select_ready_issue", return_value=6):
+                            with patch(
+                                "shinobi.cli.load_issue",
+                                return_value={"number": 6, "title": "Run start phase"},
+                            ):
+                                with patch(
+                                    "shinobi.cli.start_mission",
+                                    return_value=started_mission,
+                                ):
+                                    with patch(
+                                        "shinobi.cli.execute_verification",
+                                        return_value=execution_result,
+                                    ):
+                                        with patch(
+                                            "shinobi.cli.detect_high_risk_stop",
+                                            return_value=stop_decision,
+                                        ):
+                                            with patch(
+                                                "shinobi.cli.handoff_started_mission"
+                                            ) as handoff_mock:
+                                                with patch(
+                                                    "shinobi.cli.publish_mission"
+                                                ) as publish_mock:
+                                                    with redirect_stdout(output):
+                                                        exit_code = cli.main(["run"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn(
+                "run aborted: Shinobi stopped before publish because changed files match "
+                "high-risk path(s): auth/ (files: auth/login.py)",
+                output.getvalue(),
+            )
+            handoff_mock.assert_called_once()
+            self.assertEqual(
+                handoff_mock.call_args.kwargs["reason"],
+                stop_decision.reason,
+            )
             publish_mock.assert_not_called()
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
@@ -4202,6 +4289,69 @@ class ExecutorTest(unittest.TestCase):
             [call.args[0] for call in run_mock.call_args_list],
             [["lint-command"], ["typecheck-command"], ["test-command"]],
         )
+
+    def test_collect_changed_paths_wraps_git_failures(self) -> None:
+        with patch(
+            "shinobi.executor.subprocess.run",
+            return_value=Mock(returncode=1, stdout="", stderr="unknown revision"),
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "failed to collect changed paths against main: unknown revision",
+            ):
+                collect_changed_paths(Path("/tmp/repo"), base_ref="main")
+
+    def test_find_high_risk_paths_matches_directory_prefixes(self) -> None:
+        matched = find_high_risk_paths(
+            changed_paths=["src/app.py", "auth/login.py", "billing/invoice.py"],
+            high_risk_paths=["auth/", "billing/", "infra/"],
+        )
+
+        self.assertEqual(matched, ["auth/", "billing/"])
+
+    def test_detect_high_risk_stop_returns_structured_decision(self) -> None:
+        response = subprocess.CompletedProcess(
+            args=["git", "diff"],
+            returncode=0,
+            stdout="src/app.py\nauth/login.py\n",
+            stderr="",
+        )
+
+        with patch("shinobi.executor.subprocess.run", return_value=response):
+            decision = detect_high_risk_stop(
+                Path("/tmp/repo"),
+                Config(repo="owner/repo", high_risk_paths=["auth/", "billing/"]),
+            )
+
+        self.assertEqual(
+            decision,
+            StopDecision(
+                reason=(
+                    "Shinobi stopped before publish because changed files match "
+                    "high-risk path(s): auth/ (files: auth/login.py)"
+                ),
+                conclusion="needs-human",
+                retryable=False,
+                changed_paths=["auth/login.py"],
+                matched_paths=["auth/"],
+            ),
+        )
+
+    def test_detect_high_risk_stop_returns_none_for_safe_paths(self) -> None:
+        response = subprocess.CompletedProcess(
+            args=["git", "diff"],
+            returncode=0,
+            stdout="src/app.py\ntests/test_cli.py\n",
+            stderr="",
+        )
+
+        with patch("shinobi.executor.subprocess.run", return_value=response):
+            decision = detect_high_risk_stop(
+                Path("/tmp/repo"),
+                Config(repo="owner/repo", high_risk_paths=["auth/", "billing/"]),
+            )
+
+        self.assertIsNone(decision)
 
     def test_config_preserves_custom_verification_commands(self) -> None:
         config = Config.from_dict(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -958,10 +958,17 @@ class CliTest(unittest.TestCase):
                                             return_value=stop_decision,
                                         ):
                                             with patch(
-                                                "shinobi.cli.handoff_started_mission"
+                                                "shinobi.cli.handoff_published_mission"
                                             ) as handoff_mock:
                                                 with patch(
-                                                    "shinobi.cli.publish_mission"
+                                                    "shinobi.cli.publish_mission",
+                                                    return_value=Mock(
+                                                        pr_number=31,
+                                                        pr_url="https://github.com/owner/repo/pull/31",
+                                                        branch=started_mission.branch,
+                                                        issue_number=started_mission.issue_number,
+                                                        lease_expires_at="2026-04-09T00:30:00Z",
+                                                    ),
                                                 ) as publish_mock:
                                                     with redirect_stdout(output):
                                                         exit_code = cli.main(["run"])
@@ -977,7 +984,7 @@ class CliTest(unittest.TestCase):
                 handoff_mock.call_args.kwargs["reason"],
                 stop_decision.reason,
             )
-            publish_mock.assert_not_called()
+            publish_mock.assert_called_once()
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
     def test_run_refuses_active_github_mission_before_selecting_ready_issue(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4309,6 +4309,14 @@ class ExecutorTest(unittest.TestCase):
 
         self.assertEqual(matched, ["auth/", "billing/"])
 
+    def test_find_high_risk_paths_preserves_dot_prefixed_paths(self) -> None:
+        matched = find_high_risk_paths(
+            changed_paths=[".github/workflows/release.yml", "src/app.py"],
+            high_risk_paths=[".github/", "auth/"],
+        )
+
+        self.assertEqual(matched, [".github/"])
+
     def test_detect_high_risk_stop_returns_structured_decision(self) -> None:
         response = subprocess.CompletedProcess(
             args=["git", "diff"],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4626,7 +4626,7 @@ class ExecutorTest(unittest.TestCase):
             subprocess.CompletedProcess(
                 args=["git", "diff"],
                 returncode=0,
-                stdout="auth/login.py\n",
+                stdout="M\tauth/login.py\n",
                 stderr="",
             ),
             subprocess.CompletedProcess(
@@ -4655,11 +4655,11 @@ class ExecutorTest(unittest.TestCase):
         self.assertEqual(changed, ["auth/login.py"])
         self.assertEqual(
             run_mock.call_args_list[0].args[0],
-            ["git", "diff", "--name-only", "--diff-filter=ACMRD", "main...HEAD"],
+            ["git", "diff", "--name-status", "--diff-filter=ACMRD", "main...HEAD"],
         )
         self.assertEqual(
             run_mock.call_args_list[1].args[0],
-            ["git", "diff", "--name-only", "--diff-filter=ACMRD", "origin/main...HEAD"],
+            ["git", "diff", "--name-status", "--diff-filter=ACMRD", "origin/main...HEAD"],
         )
 
     def test_collect_changed_paths_includes_deleted_staged_unstaged_and_untracked_files(self) -> None:
@@ -4667,19 +4667,19 @@ class ExecutorTest(unittest.TestCase):
             subprocess.CompletedProcess(
                 args=["git", "diff"],
                 returncode=0,
-                stdout="src/app.py\nauth/deleted.py\n",
+                stdout="M\tsrc/app.py\nD\tauth/deleted.py\n",
                 stderr="",
             ),
             subprocess.CompletedProcess(
                 args=["git", "diff", "--cached"],
                 returncode=0,
-                stdout="auth/staged.py\n",
+                stdout="M\tauth/staged.py\n",
                 stderr="",
             ),
             subprocess.CompletedProcess(
                 args=["git", "diff"],
                 returncode=0,
-                stdout="auth/working_tree.py\n",
+                stdout="M\tauth/working_tree.py\n",
                 stderr="",
             ),
             subprocess.CompletedProcess(
@@ -4704,6 +4704,47 @@ class ExecutorTest(unittest.TestCase):
             ],
         )
 
+    def test_collect_changed_paths_includes_both_paths_for_renames_and_copies(self) -> None:
+        responses = [
+            subprocess.CompletedProcess(
+                args=["git", "diff"],
+                returncode=0,
+                stdout="R100\tauth/legacy.py\tsrc/legacy.py\nC100\tbilling/base.py\tbilling/copied.py\n",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "diff", "--cached"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "diff"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "ls-files"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+        ]
+
+        with patch("shinobi.executor.subprocess.run", side_effect=responses):
+            changed = collect_changed_paths(Path("/tmp/repo"), base_ref="main")
+
+        self.assertEqual(
+            changed,
+            [
+                "auth/legacy.py",
+                "billing/base.py",
+                "billing/copied.py",
+                "src/legacy.py",
+            ],
+        )
+
     def test_find_high_risk_paths_matches_directory_prefixes(self) -> None:
         matched = find_high_risk_paths(
             changed_paths=["src/app.py", "auth/login.py", "billing/invoice.py"],
@@ -4724,7 +4765,7 @@ class ExecutorTest(unittest.TestCase):
         response = subprocess.CompletedProcess(
             args=["git", "diff"],
             returncode=0,
-            stdout="src/app.py\nauth/login.py\n",
+            stdout="M\tsrc/app.py\nM\tauth/login.py\n",
             stderr="",
         )
 
@@ -4753,7 +4794,7 @@ class ExecutorTest(unittest.TestCase):
             subprocess.CompletedProcess(
                 args=["git", "diff"],
                 returncode=0,
-                stdout="src/app.py\ntests/test_cli.py\n",
+                stdout="M\tsrc/app.py\nM\ttests/test_cli.py\n",
                 stderr="",
             ),
             subprocess.CompletedProcess(
@@ -4789,7 +4830,7 @@ class ExecutorTest(unittest.TestCase):
             subprocess.CompletedProcess(
                 args=["git", "diff"],
                 returncode=0,
-                stdout="src/app.py\nauth/deleted.py\n",
+                stdout="M\tsrc/app.py\nD\tauth/deleted.py\n",
                 stderr="",
             ),
             subprocess.CompletedProcess(
@@ -4828,6 +4869,54 @@ class ExecutorTest(unittest.TestCase):
                 conclusion="needs-human",
                 retryable=False,
                 changed_paths=["auth/deleted.py", "auth/new_file.py"],
+                matched_paths=["auth/"],
+            ),
+        )
+
+    def test_detect_high_risk_stop_detects_renamed_paths_moved_out_of_high_risk_directory(self) -> None:
+        responses = [
+            subprocess.CompletedProcess(
+                args=["git", "diff"],
+                returncode=0,
+                stdout="R100\tauth/login.py\tsrc/login.py\n",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "diff", "--cached"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "diff"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "ls-files"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+        ]
+
+        with patch("shinobi.executor.subprocess.run", side_effect=responses):
+            decision = detect_high_risk_stop(
+                Path("/tmp/repo"),
+                Config(repo="owner/repo", high_risk_paths=["auth/", "billing/"]),
+            )
+
+        self.assertEqual(
+            decision,
+            StopDecision(
+                reason=(
+                    "Shinobi stopped before publish because changed files match "
+                    "high-risk path(s): auth/ (files: auth/login.py)"
+                ),
+                conclusion="needs-human",
+                retryable=False,
+                changed_paths=["auth/login.py"],
                 matched_paths=["auth/"],
             ),
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -860,13 +860,6 @@ class CliTest(unittest.TestCase):
                         issue_number=6,
                         lease_expires_at="2026-04-09T00:30:00Z",
                     )
-                    published_mission = Mock(
-                        branch="feature/issue-6-run-start-phase",
-                        issue_number=6,
-                        pr_number=31,
-                        pr_url="https://github.com/owner/repo/pull/31",
-                        lease_expires_at="2026-04-09T00:30:00Z",
-                    )
                     execution_result = ExecutionResult(
                         commands=[
                             VerificationCommandResult(
@@ -972,11 +965,10 @@ class CliTest(unittest.TestCase):
                                             return_value=stop_decision,
                                         ):
                                             with patch(
-                                                "shinobi.cli.handoff_published_mission"
+                                                "shinobi.cli.handoff_started_mission"
                                             ) as handoff_mock:
                                                 with patch(
                                                     "shinobi.cli.publish_mission",
-                                                    return_value=published_mission,
                                                 ) as publish_mock:
                                                     with redirect_stdout(output):
                                                         exit_code = cli.main(["run"])
@@ -992,7 +984,7 @@ class CliTest(unittest.TestCase):
                 handoff_mock.call_args.kwargs["reason"],
                 stop_decision.reason,
             )
-            publish_mock.assert_called_once()
+            publish_mock.assert_not_called()
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
     def test_run_hands_off_when_pre_publish_stop_requests_unsupported_conclusion(self) -> None:
@@ -1008,13 +1000,6 @@ class CliTest(unittest.TestCase):
                     started_mission = Mock(
                         branch="feature/issue-6-run-start-phase",
                         issue_number=6,
-                        lease_expires_at="2026-04-09T00:30:00Z",
-                    )
-                    published_mission = Mock(
-                        branch="feature/issue-6-run-start-phase",
-                        issue_number=6,
-                        pr_number=31,
-                        pr_url="https://github.com/owner/repo/pull/31",
                         lease_expires_at="2026-04-09T00:30:00Z",
                     )
                     execution_result = ExecutionResult(
@@ -1053,11 +1038,10 @@ class CliTest(unittest.TestCase):
                                             return_value=stop_decision,
                                         ):
                                             with patch(
-                                                "shinobi.cli.handoff_published_mission"
+                                                "shinobi.cli.handoff_started_mission"
                                             ) as handoff_mock:
                                                 with patch(
                                                     "shinobi.cli.publish_mission",
-                                                    return_value=published_mission,
                                                 ) as publish_mock:
                                                     with redirect_stdout(output):
                                                         exit_code = cli.main(["run"])
@@ -1076,7 +1060,7 @@ class CliTest(unittest.TestCase):
                 "handing off to needs-human instead. Original reason: "
                 "Shinobi stopped before publish because auth changes require block.",
             )
-            publish_mock.assert_called_once()
+            publish_mock.assert_not_called()
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
     def test_run_hands_off_when_high_risk_detection_fails_before_publish(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4615,6 +4615,53 @@ class ExecutorTest(unittest.TestCase):
             ):
                 collect_changed_paths(Path("/tmp/repo"), base_ref="main")
 
+    def test_collect_changed_paths_falls_back_to_origin_main_when_local_main_is_missing(self) -> None:
+        responses = [
+            subprocess.CompletedProcess(
+                args=["git", "diff"],
+                returncode=1,
+                stdout="",
+                stderr="unknown revision",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "diff"],
+                returncode=0,
+                stdout="auth/login.py\n",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "diff", "--cached"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "diff"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "ls-files"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+        ]
+
+        with patch("shinobi.executor.subprocess.run", side_effect=responses) as run_mock:
+            changed = collect_changed_paths(Path("/tmp/repo"), base_ref="main")
+
+        self.assertEqual(changed, ["auth/login.py"])
+        self.assertEqual(
+            run_mock.call_args_list[0].args[0],
+            ["git", "diff", "--name-only", "--diff-filter=ACMRD", "main...HEAD"],
+        )
+        self.assertEqual(
+            run_mock.call_args_list[1].args[0],
+            ["git", "diff", "--name-only", "--diff-filter=ACMRD", "origin/main...HEAD"],
+        )
+
     def test_collect_changed_paths_includes_deleted_staged_unstaged_and_untracked_files(self) -> None:
         responses = [
             subprocess.CompletedProcess(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4615,7 +4615,44 @@ class ExecutorTest(unittest.TestCase):
             ):
                 collect_changed_paths(Path("/tmp/repo"), base_ref="main")
 
-    def test_collect_changed_paths_falls_back_to_origin_main_when_local_main_is_missing(self) -> None:
+    def test_collect_changed_paths_prefers_origin_main_before_local_main(self) -> None:
+        responses = [
+            subprocess.CompletedProcess(
+                args=["git", "diff"],
+                returncode=0,
+                stdout="M\tauth/login.py\n",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "diff", "--cached"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "diff"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "ls-files"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+        ]
+
+        with patch("shinobi.executor.subprocess.run", side_effect=responses) as run_mock:
+            changed = collect_changed_paths(Path("/tmp/repo"), base_ref="main")
+
+        self.assertEqual(changed, ["auth/login.py"])
+        self.assertEqual(
+            run_mock.call_args_list[0].args[0],
+            ["git", "diff", "--name-status", "--diff-filter=ACMRD", "origin/main...HEAD"],
+        )
+
+    def test_collect_changed_paths_falls_back_to_local_main_when_origin_main_is_missing(self) -> None:
         responses = [
             subprocess.CompletedProcess(
                 args=["git", "diff"],
@@ -4655,11 +4692,11 @@ class ExecutorTest(unittest.TestCase):
         self.assertEqual(changed, ["auth/login.py"])
         self.assertEqual(
             run_mock.call_args_list[0].args[0],
-            ["git", "diff", "--name-status", "--diff-filter=ACMRD", "main...HEAD"],
+            ["git", "diff", "--name-status", "--diff-filter=ACMRD", "origin/main...HEAD"],
         )
         self.assertEqual(
             run_mock.call_args_list[1].args[0],
-            ["git", "diff", "--name-status", "--diff-filter=ACMRD", "origin/main...HEAD"],
+            ["git", "diff", "--name-status", "--diff-filter=ACMRD", "main...HEAD"],
         )
 
     def test_collect_changed_paths_includes_deleted_staged_unstaged_and_untracked_files(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -958,17 +958,10 @@ class CliTest(unittest.TestCase):
                                             return_value=stop_decision,
                                         ):
                                             with patch(
-                                                "shinobi.cli.handoff_published_mission"
+                                                "shinobi.cli.handoff_started_mission"
                                             ) as handoff_mock:
                                                 with patch(
                                                     "shinobi.cli.publish_mission",
-                                                    return_value=Mock(
-                                                        pr_number=31,
-                                                        pr_url="https://github.com/owner/repo/pull/31",
-                                                        branch=started_mission.branch,
-                                                        issue_number=started_mission.issue_number,
-                                                        lease_expires_at="2026-04-09T00:30:00Z",
-                                                    ),
                                                 ) as publish_mock:
                                                     with redirect_stdout(output):
                                                         exit_code = cli.main(["run"])
@@ -984,7 +977,7 @@ class CliTest(unittest.TestCase):
                 handoff_mock.call_args.kwargs["reason"],
                 stop_decision.reason,
             )
-            publish_mock.assert_called_once()
+            publish_mock.assert_not_called()
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
     def test_run_hands_off_when_high_risk_detection_fails_before_publish(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -821,19 +821,23 @@ class CliTest(unittest.TestCase):
                                         return_value=execution_result,
                                     ):
                                         with patch(
-                                            "shinobi.cli.detect_high_risk_stop",
-                                            return_value=None,
+                                            "shinobi.cli.load_publishable_issue_label_names",
+                                            return_value={"shinobi:working"},
                                         ):
                                             with patch(
-                                                "shinobi.cli.publish_mission",
-                                                return_value=Mock(
-                                                    pr_number=31,
-                                                    pr_url="https://github.com/owner/repo/pull/31",
-                                                    lease_expires_at="2026-04-09T00:30:00Z",
-                                                ),
-                                            ) as publish_mock:
-                                                with redirect_stdout(output):
-                                                    exit_code = cli.main(["run"])
+                                                "shinobi.cli.detect_high_risk_stop",
+                                                return_value=None,
+                                            ):
+                                                with patch(
+                                                    "shinobi.cli.publish_mission",
+                                                    return_value=Mock(
+                                                        pr_number=31,
+                                                        pr_url="https://github.com/owner/repo/pull/31",
+                                                        lease_expires_at="2026-04-09T00:30:00Z",
+                                                    ),
+                                                ) as publish_mock:
+                                                    with redirect_stdout(output):
+                                                        exit_code = cli.main(["run"])
 
             self.assertEqual(exit_code, 0)
             rendered = output.getvalue()
@@ -961,17 +965,21 @@ class CliTest(unittest.TestCase):
                                         return_value=execution_result,
                                     ):
                                         with patch(
-                                            "shinobi.cli.detect_high_risk_stop",
-                                            return_value=stop_decision,
+                                            "shinobi.cli.load_publishable_issue_label_names",
+                                            return_value={"shinobi:working"},
                                         ):
                                             with patch(
-                                                "shinobi.cli.handoff_started_mission"
-                                            ) as handoff_mock:
+                                                "shinobi.cli.detect_high_risk_stop",
+                                                return_value=stop_decision,
+                                            ):
                                                 with patch(
-                                                    "shinobi.cli.publish_mission",
-                                                ) as publish_mock:
-                                                    with redirect_stdout(output):
-                                                        exit_code = cli.main(["run"])
+                                                    "shinobi.cli.handoff_started_mission"
+                                                ) as handoff_mock:
+                                                    with patch(
+                                                        "shinobi.cli.publish_mission",
+                                                    ) as publish_mock:
+                                                        with redirect_stdout(output):
+                                                            exit_code = cli.main(["run"])
 
             self.assertEqual(exit_code, 1)
             self.assertIn(
@@ -985,6 +993,80 @@ class CliTest(unittest.TestCase):
                 stop_decision.reason,
             )
             publish_mock.assert_not_called()
+            self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
+
+    def test_run_prefers_existing_blocking_label_before_high_risk_handoff(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    output = io.StringIO()
+                    started_mission = Mock(
+                        branch="feature/issue-6-run-start-phase",
+                        issue_number=6,
+                        lease_expires_at="2026-04-09T00:30:00Z",
+                    )
+                    execution_result = ExecutionResult(
+                        commands=[
+                            VerificationCommandResult(
+                                name="test",
+                                command=["python3", "-m", "unittest"],
+                                status="passed",
+                                returncode=0,
+                            )
+                        ],
+                        change_summary="Changed auth flow.",
+                    )
+                    with patch("shinobi.cli.list_open_issues_with_any_label", return_value=[]):
+                        with patch("shinobi.cli.select_ready_issue", return_value=6):
+                            with patch(
+                                "shinobi.cli.load_issue",
+                                return_value={"number": 6, "title": "Run start phase"},
+                            ):
+                                with patch(
+                                    "shinobi.cli.start_mission",
+                                    return_value=started_mission,
+                                ):
+                                    with patch(
+                                        "shinobi.cli.execute_verification",
+                                        return_value=execution_result,
+                                    ):
+                                        with patch(
+                                            "shinobi.cli.load_publishable_issue_label_names",
+                                            return_value={"shinobi:blocked", "shinobi:working"},
+                                        ):
+                                            with patch(
+                                                "shinobi.cli.detect_high_risk_stop"
+                                            ) as detect_mock:
+                                                with patch(
+                                                    "shinobi.cli.handoff_started_mission"
+                                                ) as handoff_mock:
+                                                    with patch(
+                                                        "shinobi.cli.publish_mission",
+                                                    ) as publish_mock:
+                                                        with redirect_stdout(output):
+                                                            exit_code = cli.main(["run"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn(
+                "run aborted: publish phase cannot proceed because issue #6 "
+                "has blocking label(s): shinobi:blocked",
+                output.getvalue(),
+            )
+            detect_mock.assert_not_called()
+            handoff_mock.assert_not_called()
+            publish_mock.assert_not_called()
+            saved_state = store.load_state()
+            self.assertEqual(saved_state.phase, "idle")
+            self.assertEqual(saved_state.last_result, "blocked")
+            self.assertEqual(saved_state.last_error, "publish phase cannot proceed because issue #6 has blocking label(s): shinobi:blocked")
+            self.assertIsNotNone(saved_state.last_mission)
+            self.assertEqual(saved_state.last_mission.phase, "publish")
+            self.assertEqual(saved_state.last_mission.conclusion, "blocked")
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
     def test_run_hands_off_when_pre_publish_stop_requests_unsupported_conclusion(self) -> None:
@@ -1034,17 +1116,21 @@ class CliTest(unittest.TestCase):
                                         return_value=execution_result,
                                     ):
                                         with patch(
-                                            "shinobi.cli.detect_high_risk_stop",
-                                            return_value=stop_decision,
+                                            "shinobi.cli.load_publishable_issue_label_names",
+                                            return_value={"shinobi:working"},
                                         ):
                                             with patch(
-                                                "shinobi.cli.handoff_started_mission"
-                                            ) as handoff_mock:
+                                                "shinobi.cli.detect_high_risk_stop",
+                                                return_value=stop_decision,
+                                            ):
                                                 with patch(
-                                                    "shinobi.cli.publish_mission",
-                                                ) as publish_mock:
-                                                    with redirect_stdout(output):
-                                                        exit_code = cli.main(["run"])
+                                                    "shinobi.cli.handoff_started_mission"
+                                                ) as handoff_mock:
+                                                    with patch(
+                                                        "shinobi.cli.publish_mission",
+                                                    ) as publish_mock:
+                                                        with redirect_stdout(output):
+                                                            exit_code = cli.main(["run"])
 
             self.assertEqual(exit_code, 1)
             self.assertIn(
@@ -1104,17 +1190,21 @@ class CliTest(unittest.TestCase):
                                         return_value=execution_result,
                                     ):
                                         with patch(
-                                            "shinobi.cli.detect_high_risk_stop",
-                                            side_effect=RuntimeError("unknown revision"),
+                                            "shinobi.cli.load_publishable_issue_label_names",
+                                            return_value={"shinobi:working"},
                                         ):
                                             with patch(
-                                                "shinobi.cli.handoff_started_mission"
-                                            ) as handoff_mock:
+                                                "shinobi.cli.detect_high_risk_stop",
+                                                side_effect=RuntimeError("unknown revision"),
+                                            ):
                                                 with patch(
-                                                    "shinobi.cli.publish_mission"
-                                                ) as publish_mock:
-                                                    with redirect_stdout(output):
-                                                        exit_code = cli.main(["run"])
+                                                    "shinobi.cli.handoff_started_mission"
+                                                ) as handoff_mock:
+                                                    with patch(
+                                                        "shinobi.cli.publish_mission"
+                                                    ) as publish_mock:
+                                                        with redirect_stdout(output):
+                                                            exit_code = cli.main(["run"])
 
             self.assertEqual(exit_code, 1)
             self.assertIn(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1220,6 +1220,80 @@ class CliTest(unittest.TestCase):
             publish_mock.assert_not_called()
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
+    def test_run_hands_off_when_issue_reload_fails_before_pre_publish_stop_check(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    output = io.StringIO()
+                    started_mission = Mock(
+                        branch="feature/issue-6-run-start-phase",
+                        issue_number=6,
+                        lease_expires_at="2026-04-09T00:30:00Z",
+                    )
+                    execution_result = ExecutionResult(
+                        commands=[
+                            VerificationCommandResult(
+                                name="test",
+                                command=["python3", "-m", "unittest"],
+                                status="passed",
+                                returncode=0,
+                            )
+                        ],
+                        change_summary="Changed auth flow.",
+                    )
+                    with patch("shinobi.cli.list_open_issues_with_any_label", return_value=[]):
+                        with patch("shinobi.cli.select_ready_issue", return_value=6):
+                            with patch(
+                                "shinobi.cli.load_issue",
+                                return_value={"number": 6, "title": "Run start phase"},
+                            ):
+                                with patch(
+                                    "shinobi.cli.start_mission",
+                                    return_value=started_mission,
+                                ):
+                                    with patch(
+                                        "shinobi.cli.execute_verification",
+                                        return_value=execution_result,
+                                    ):
+                                        with patch(
+                                            "shinobi.cli.load_publishable_issue_label_names",
+                                            side_effect=MissionPublishError(
+                                                "failed to load issue #6 before publish: api unavailable"
+                                            ),
+                                        ):
+                                            with patch(
+                                                "shinobi.cli.handoff_started_mission"
+                                            ) as handoff_mock:
+                                                with patch(
+                                                    "shinobi.cli.detect_high_risk_stop"
+                                                ) as detect_mock:
+                                                    with patch(
+                                                        "shinobi.cli.publish_mission"
+                                                    ) as publish_mock:
+                                                        with redirect_stdout(output):
+                                                            exit_code = cli.main(["run"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn(
+                "run aborted: Shinobi failed to evaluate pre-publish stop conditions: "
+                "failed to load issue #6 before publish: api unavailable",
+                output.getvalue(),
+            )
+            handoff_mock.assert_called_once()
+            self.assertEqual(
+                handoff_mock.call_args.kwargs["reason"],
+                "Shinobi failed to evaluate pre-publish stop conditions: "
+                "failed to load issue #6 before publish: api unavailable",
+            )
+            detect_mock.assert_not_called()
+            publish_mock.assert_not_called()
+            self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
+
     def test_run_refuses_active_github_mission_before_selecting_ready_issue(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4451,6 +4451,48 @@ class ExecutorTest(unittest.TestCase):
             ):
                 collect_changed_paths(Path("/tmp/repo"), base_ref="main")
 
+    def test_collect_changed_paths_includes_deleted_staged_unstaged_and_untracked_files(self) -> None:
+        responses = [
+            subprocess.CompletedProcess(
+                args=["git", "diff"],
+                returncode=0,
+                stdout="src/app.py\nauth/deleted.py\n",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "diff", "--cached"],
+                returncode=0,
+                stdout="auth/staged.py\n",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "diff"],
+                returncode=0,
+                stdout="auth/working_tree.py\n",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "ls-files"],
+                returncode=0,
+                stdout="auth/new_file.py\n",
+                stderr="",
+            ),
+        ]
+
+        with patch("shinobi.executor.subprocess.run", side_effect=responses):
+            changed = collect_changed_paths(Path("/tmp/repo"), base_ref="main")
+
+        self.assertEqual(
+            changed,
+            [
+                "auth/deleted.py",
+                "auth/new_file.py",
+                "auth/staged.py",
+                "auth/working_tree.py",
+                "src/app.py",
+            ],
+        )
+
     def test_find_high_risk_paths_matches_directory_prefixes(self) -> None:
         matched = find_high_risk_paths(
             changed_paths=["src/app.py", "auth/login.py", "billing/invoice.py"],
@@ -4496,20 +4538,88 @@ class ExecutorTest(unittest.TestCase):
         )
 
     def test_detect_high_risk_stop_returns_none_for_safe_paths(self) -> None:
-        response = subprocess.CompletedProcess(
-            args=["git", "diff"],
-            returncode=0,
-            stdout="src/app.py\ntests/test_cli.py\n",
-            stderr="",
-        )
+        responses = [
+            subprocess.CompletedProcess(
+                args=["git", "diff"],
+                returncode=0,
+                stdout="src/app.py\ntests/test_cli.py\n",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "diff", "--cached"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "diff"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "ls-files"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+        ]
 
-        with patch("shinobi.executor.subprocess.run", return_value=response):
+        with patch("shinobi.executor.subprocess.run", side_effect=responses):
             decision = detect_high_risk_stop(
                 Path("/tmp/repo"),
                 Config(repo="owner/repo", high_risk_paths=["auth/", "billing/"]),
             )
 
         self.assertIsNone(decision)
+
+    def test_detect_high_risk_stop_detects_deleted_and_untracked_high_risk_paths(self) -> None:
+        responses = [
+            subprocess.CompletedProcess(
+                args=["git", "diff"],
+                returncode=0,
+                stdout="src/app.py\nauth/deleted.py\n",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "diff", "--cached"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "diff"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["git", "ls-files"],
+                returncode=0,
+                stdout="auth/new_file.py\n",
+                stderr="",
+            ),
+        ]
+
+        with patch("shinobi.executor.subprocess.run", side_effect=responses):
+            decision = detect_high_risk_stop(
+                Path("/tmp/repo"),
+                Config(repo="owner/repo", high_risk_paths=["auth/", "billing/"]),
+            )
+
+        self.assertEqual(
+            decision,
+            StopDecision(
+                reason=(
+                    "Shinobi stopped before publish because changed files match "
+                    "high-risk path(s): auth/ (files: auth/deleted.py, auth/new_file.py)"
+                ),
+                conclusion="needs-human",
+                retryable=False,
+                changed_paths=["auth/deleted.py", "auth/new_file.py"],
+                matched_paths=["auth/"],
+            ),
+        )
 
     def test_config_preserves_custom_verification_commands(self) -> None:
         config = Config.from_dict(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -980,6 +980,82 @@ class CliTest(unittest.TestCase):
             publish_mock.assert_not_called()
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
+    def test_run_hands_off_when_pre_publish_stop_requests_unsupported_conclusion(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    output = io.StringIO()
+                    started_mission = Mock(
+                        branch="feature/issue-6-run-start-phase",
+                        issue_number=6,
+                        lease_expires_at="2026-04-09T00:30:00Z",
+                    )
+                    execution_result = ExecutionResult(
+                        commands=[
+                            VerificationCommandResult(
+                                name="test",
+                                command=["python3", "-m", "unittest"],
+                                status="passed",
+                                returncode=0,
+                            )
+                        ],
+                        change_summary="Changed auth flow.",
+                    )
+                    stop_decision = StopDecision(
+                        reason="Shinobi stopped before publish because auth changes require block.",
+                        conclusion="blocked",
+                        changed_paths=["auth/login.py"],
+                        matched_paths=["auth/"],
+                    )
+                    with patch("shinobi.cli.list_open_issues_with_any_label", return_value=[]):
+                        with patch("shinobi.cli.select_ready_issue", return_value=6):
+                            with patch(
+                                "shinobi.cli.load_issue",
+                                return_value={"number": 6, "title": "Run start phase"},
+                            ):
+                                with patch(
+                                    "shinobi.cli.start_mission",
+                                    return_value=started_mission,
+                                ):
+                                    with patch(
+                                        "shinobi.cli.execute_verification",
+                                        return_value=execution_result,
+                                    ):
+                                        with patch(
+                                            "shinobi.cli.detect_high_risk_stop",
+                                            return_value=stop_decision,
+                                        ):
+                                            with patch(
+                                                "shinobi.cli.handoff_started_mission"
+                                            ) as handoff_mock:
+                                                with patch(
+                                                    "shinobi.cli.publish_mission",
+                                                ) as publish_mock:
+                                                    with redirect_stdout(output):
+                                                        exit_code = cli.main(["run"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn(
+                "run aborted: pre-publish stop requested unsupported conclusion blocked; "
+                "handing off to needs-human instead. Original reason: "
+                "Shinobi stopped before publish because auth changes require block.",
+                output.getvalue(),
+            )
+            handoff_mock.assert_called_once()
+            self.assertEqual(
+                handoff_mock.call_args.kwargs["reason"],
+                "pre-publish stop requested unsupported conclusion blocked; "
+                "handing off to needs-human instead. Original reason: "
+                "Shinobi stopped before publish because auth changes require block.",
+            )
+            publish_mock.assert_not_called()
+            self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
+
     def test_run_hands_off_when_high_risk_detection_fails_before_publish(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -860,6 +860,13 @@ class CliTest(unittest.TestCase):
                         issue_number=6,
                         lease_expires_at="2026-04-09T00:30:00Z",
                     )
+                    published_mission = Mock(
+                        branch="feature/issue-6-run-start-phase",
+                        issue_number=6,
+                        pr_number=31,
+                        pr_url="https://github.com/owner/repo/pull/31",
+                        lease_expires_at="2026-04-09T00:30:00Z",
+                    )
                     execution_result = ExecutionResult(
                         commands=[
                             VerificationCommandResult(
@@ -919,6 +926,13 @@ class CliTest(unittest.TestCase):
                         issue_number=6,
                         lease_expires_at="2026-04-09T00:30:00Z",
                     )
+                    published_mission = Mock(
+                        branch="feature/issue-6-run-start-phase",
+                        issue_number=6,
+                        pr_number=31,
+                        pr_url="https://github.com/owner/repo/pull/31",
+                        lease_expires_at="2026-04-09T00:30:00Z",
+                    )
                     execution_result = ExecutionResult(
                         commands=[
                             VerificationCommandResult(
@@ -958,10 +972,11 @@ class CliTest(unittest.TestCase):
                                             return_value=stop_decision,
                                         ):
                                             with patch(
-                                                "shinobi.cli.handoff_started_mission"
+                                                "shinobi.cli.handoff_published_mission"
                                             ) as handoff_mock:
                                                 with patch(
                                                     "shinobi.cli.publish_mission",
+                                                    return_value=published_mission,
                                                 ) as publish_mock:
                                                     with redirect_stdout(output):
                                                         exit_code = cli.main(["run"])
@@ -977,7 +992,7 @@ class CliTest(unittest.TestCase):
                 handoff_mock.call_args.kwargs["reason"],
                 stop_decision.reason,
             )
-            publish_mock.assert_not_called()
+            publish_mock.assert_called_once()
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
     def test_run_hands_off_when_pre_publish_stop_requests_unsupported_conclusion(self) -> None:
@@ -993,6 +1008,13 @@ class CliTest(unittest.TestCase):
                     started_mission = Mock(
                         branch="feature/issue-6-run-start-phase",
                         issue_number=6,
+                        lease_expires_at="2026-04-09T00:30:00Z",
+                    )
+                    published_mission = Mock(
+                        branch="feature/issue-6-run-start-phase",
+                        issue_number=6,
+                        pr_number=31,
+                        pr_url="https://github.com/owner/repo/pull/31",
                         lease_expires_at="2026-04-09T00:30:00Z",
                     )
                     execution_result = ExecutionResult(
@@ -1031,10 +1053,11 @@ class CliTest(unittest.TestCase):
                                             return_value=stop_decision,
                                         ):
                                             with patch(
-                                                "shinobi.cli.handoff_started_mission"
+                                                "shinobi.cli.handoff_published_mission"
                                             ) as handoff_mock:
                                                 with patch(
                                                     "shinobi.cli.publish_mission",
+                                                    return_value=published_mission,
                                                 ) as publish_mock:
                                                     with redirect_stdout(output):
                                                         exit_code = cli.main(["run"])
@@ -1053,7 +1076,7 @@ class CliTest(unittest.TestCase):
                 "handing off to needs-human instead. Original reason: "
                 "Shinobi stopped before publish because auth changes require block.",
             )
-            publish_mock.assert_not_called()
+            publish_mock.assert_called_once()
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
     def test_run_hands_off_when_high_risk_detection_fails_before_publish(self) -> None:


### PR DESCRIPTION
## Summary
- add structured `StopDecision` support for pre-publish stop conditions
- detect changed files under configured high-risk paths before publish
- hand off start-phase missions to `needs-human` when high-risk paths are touched

## Testing
- env PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m compileall src tests
- python3 -m unittest tests.test_cli

## Notes
- Refs #30
- This change currently routes high-risk path stops to `needs-human`; blocked-specific routing can build on the same structured decision later.
