### PR TITLE
Implement CI polling for review phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,12 @@ shinobi init
 shinobi status
 shinobi run
 shinobi run --issue 123
+shinobi review
 ```
 
-`watch` や phase 分離コマンドは将来候補です。MVP の公開 CLI には含めません。
+`watch` や merge などの後続コマンドは将来候補です。
 
-現在の実装では foundations に加えて、`shinobi run` / `shinobi run --issue <id>` の select / start / publish phase まで実装しています。Issue 選択、`.shinobi/run.lock` によるローカル排他、`feature/issue-<id>-<slug>` branch 作成、start 用の machine-readable comment 投稿、検証コマンド実行、branch push、draft PR 作成または更新、publish 用の label / mission-state comment 更新が動作します。context builder は Issue とローカル knowledge から最小実行コンテキストを構築できますが、run phase への統合は未実装です。
+現在の実装では foundations に加えて、`shinobi run` / `shinobi run --issue <id>` の select / start / publish phase と、`shinobi review` の CI polling が動作します。Issue 選択、`.shinobi/run.lock` によるローカル排他、`feature/issue-<id>-<slug>` branch 作成、start 用の machine-readable comment 投稿、検証コマンド実行、branch push、draft PR 作成または更新、publish 用の label / mission-state comment 更新、review phase の CI 待機結果の state 保存まで実装済みです。context builder の run phase 統合、review loop の自動修正、auto-merge は未実装です。
 
 ## ドキュメント構成
 
@@ -87,4 +88,4 @@ shinobi run --issue 123
 
 ## 現在の状態
 
-このリポジトリは foundations 実装に加え、`run` の start / publish phase と context builder を持ちます。現在は `.shinobi/` の初期化、ローカル state/config の保存、`status` のローカル表示と GitHub 照合、`run` の issue 選択、stale/live lock 判定、branch 作成、start 用 comment 投稿、GitHub label の start 遷移、検証コマンド実行、branch push、draft PR 作成または更新、publish 用 comment / label / state 更新、Issue 由来の最小 context 構築までを持ちます。context phase の run 統合、review loop、自動 merge はこれから実装します。
+このリポジトリは foundations 実装に加え、`run` の start / publish phase、`review` の CI polling、context builder を持ちます。現在は `.shinobi/` の初期化、ローカル state/config の保存、`status` のローカル表示と GitHub 照合、`run` の issue 選択、stale/live lock 判定、branch 作成、start 用 comment 投稿、GitHub label の start 遷移、検証コマンド実行、branch push、draft PR 作成または更新、publish 用 comment / label / state 更新、review 用の CI 状態取得と結果保存、Issue 由来の最小 context 構築までを持ちます。context phase の run 統合、review loop の自動修正、自動 merge はこれから実装します。

--- a/docs/mvp-design.md
+++ b/docs/mvp-design.md
@@ -67,16 +67,17 @@ shinobi status
 
 ## CLI 設計
 
-MVP では次の 4 コマンドをサポートします。
+MVP では次の 5 コマンドをサポートします。
 
 ```bash
 shinobi init
 shinobi status
 shinobi run
 shinobi run --issue 123
+shinobi review
 ```
 
-`plan` `execute` `review` `merge` `watch` は将来コマンド候補ですが、MVP では公開コマンドに含めません。
+`plan` `execute` `merge` `watch` は将来コマンド候補です。
 
 ### `shinobi init`
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -199,6 +199,7 @@ shinobi init
 shinobi status
 shinobi run
 shinobi run --issue 123
+shinobi review
 ```
 
 将来コマンド候補:
@@ -206,7 +207,6 @@ shinobi run --issue 123
 ```bash
 shinobi plan --issue 123
 shinobi execute --issue 123
-shinobi review --issue 123
 shinobi merge --issue 123
 shinobi watch
 ```

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -410,6 +410,31 @@ def command_review(
 
         client = GitHubClient(root, repo=config.repo)
 
+        def persist_review_error(error_message: str) -> None:
+            try:
+                store.save_state(
+                    State(
+                        issue_number=state.issue_number,
+                        pr_number=state.pr_number,
+                        branch=state.branch,
+                        agent_identity=config.agent_identity,
+                        run_id=run_id,
+                        phase="review",
+                        review_loop_count=state.review_loop_count,
+                        retryable_local_only=False,
+                        lease_expires_at=store.format_timestamp(
+                            datetime.now(timezone.utc)
+                            + timedelta(minutes=config.mission_lease_minutes)
+                        ),
+                        last_result="review-error",
+                        last_error=error_message,
+                        last_mission=state.last_mission,
+                        extra=state.extra,
+                    )
+                )
+            except OSError:
+                pass
+
         def heartbeat() -> None:
             heartbeat_now = datetime.now(timezone.utc)
             store.refresh_lock_heartbeat(
@@ -427,6 +452,7 @@ def command_review(
                 heartbeat=heartbeat,
             )
         except (ReviewerError, RuntimeError, ValueError) as error:
+            persist_review_error(str(error))
             print(f"review aborted: {error}")
             return 1
 

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -4,7 +4,7 @@ import argparse
 import os
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, List, Optional
 
@@ -33,6 +33,7 @@ from .mission_start import (
     start_mission,
 )
 from .models import Config, ExecutionResult, State, StopDecision
+from .reviewer import ReviewerError, wait_for_ci
 from .state_store import StateStore
 
 
@@ -53,6 +54,19 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers.add_parser("status", help="Show local Shinobi state.")
     run_parser = subparsers.add_parser("run", help="Start a mission lifecycle.")
     run_parser.add_argument("--issue", type=positive_issue_number, help="Issue number to run.")
+    review_parser = subparsers.add_parser("review", help="Wait for PR CI and persist review state.")
+    review_parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=900,
+        help="Maximum time to wait for CI completion.",
+    )
+    review_parser.add_argument(
+        "--poll-interval-seconds",
+        type=float,
+        default=10,
+        help="Polling interval for CI status checks.",
+    )
     return parser
 
 
@@ -319,9 +333,165 @@ def expected_status_label(mission_ref: StatusMissionRef, config: Config) -> str 
         return None
     if mission_ref.phase == "start":
         return config.labels["working"]
-    if mission_ref.phase == "publish":
+    if mission_ref.phase in {"publish", "review"}:
         return config.labels["reviewing"]
     return None
+
+
+def command_review(
+    root: Path,
+    *,
+    timeout_seconds: float,
+    poll_interval_seconds: float,
+) -> int:
+    store = StateStore(root)
+    if not store.has_state():
+        print("Shinobi is not initialized in this workspace.")
+        print("Run `shinobi init` first.")
+        return 1
+
+    config, config_error = store.try_load_config()
+    if config is None:
+        print(f"failed to load config: {config_error}")
+        return 1
+
+    state, state_error = store.try_load_state()
+    if state is None:
+        print(f"failed to load local state: {state_error}")
+        return 1
+
+    if state.phase not in {"publish", "review"}:
+        print(
+            "review aborted: local mission state must be in publish or review phase, "
+            f"got {state.phase}"
+        )
+        return 1
+    if state.issue_number is None or state.pr_number is None or not state.branch:
+        print("review aborted: local mission state requires issue_number, pr_number, and branch")
+        return 1
+
+    run_id = uuid.uuid4().hex
+    now = datetime.now(timezone.utc)
+    try:
+        store.acquire_lock(
+            config=config,
+            run_id=run_id,
+            pid=os.getpid(),
+            now=now,
+        )
+    except (RuntimeError, ValueError) as error:
+        print(f"review aborted: {error}")
+        return 1
+
+    try:
+        try:
+            store.save_state(
+                State(
+                    issue_number=state.issue_number,
+                    pr_number=state.pr_number,
+                    branch=state.branch,
+                    agent_identity=config.agent_identity,
+                    run_id=run_id,
+                    phase="review",
+                    review_loop_count=state.review_loop_count,
+                    retryable_local_only=False,
+                    lease_expires_at=store.format_timestamp(
+                        now + timedelta(minutes=config.mission_lease_minutes)
+                    ),
+                    last_result=state.last_result,
+                    last_error=None,
+                    last_mission=state.last_mission,
+                    extra=state.extra,
+                )
+            )
+        except OSError as error:
+            print(f"review aborted: failed to persist review state: {error}")
+            return 1
+
+        client = GitHubClient(root, repo=config.repo)
+
+        def heartbeat() -> None:
+            heartbeat_now = datetime.now(timezone.utc)
+            store.refresh_lock_heartbeat(
+                run_id=run_id,
+                agent_identity=config.agent_identity,
+                now=heartbeat_now,
+            )
+
+        try:
+            ci_status = wait_for_ci(
+                client,
+                state.pr_number,
+                timeout_seconds=timeout_seconds,
+                poll_interval_seconds=poll_interval_seconds,
+                heartbeat=heartbeat,
+            )
+        except (ReviewerError, RuntimeError, ValueError) as error:
+            print(f"review aborted: {error}")
+            return 1
+
+        review_state = State(
+            issue_number=state.issue_number,
+            pr_number=state.pr_number,
+            branch=state.branch,
+            agent_identity=config.agent_identity,
+            run_id=run_id,
+            phase="review",
+            review_loop_count=state.review_loop_count,
+            retryable_local_only=False,
+            lease_expires_at=store.format_timestamp(
+                datetime.now(timezone.utc) + timedelta(minutes=config.mission_lease_minutes)
+            ),
+            last_result=render_review_result(ci_status),
+            last_error="CI polling timed out before checks completed" if ci_status.timed_out else None,
+            last_mission=state.last_mission,
+            extra={
+                **state.extra,
+                "ci_status": {
+                    "status": ci_status.status,
+                    "timed_out": ci_status.timed_out,
+                    "checks": [
+                        {
+                            "name": check.name,
+                            "state": check.state,
+                            "bucket": check.bucket,
+                            "link": check.link,
+                        }
+                        for check in ci_status.checks
+                    ],
+                },
+            },
+        )
+        try:
+            store.save_state(review_state)
+        except OSError as error:
+            print(f"review aborted: failed to persist CI review result: {error}")
+            return 1
+
+        print(f"review_issue: #{state.issue_number}")
+        print(f"review_pr: #{state.pr_number}")
+        print(f"ci_status: {ci_status.status}")
+        print(f"ci_timed_out: {ci_status.timed_out}")
+        if ci_status.checks:
+            print(
+                "ci_checks: "
+                + ", ".join(f"{check.name}={check.bucket}" for check in ci_status.checks)
+            )
+        else:
+            print("ci_checks: none")
+        return 1 if ci_status.timed_out else 0
+    finally:
+        store.clear_lock(run_id)
+
+
+def render_review_result(ci_status: Any) -> str:
+    if ci_status.timed_out:
+        return "ci-timeout"
+    if ci_status.is_failed:
+        return "ci-failure"
+    if ci_status.is_successful:
+        return "ci-success"
+    return "ci-pending"
 
 
 def command_run(root: Path, issue_number: Optional[int]) -> int:
@@ -636,6 +806,12 @@ def main(argv: Optional[List[str]] = None) -> int:
         return command_init(root)
     if args.command == "status":
         return command_status(root)
+    if args.command == "review":
+        return command_review(
+            root,
+            timeout_seconds=args.timeout_seconds,
+            poll_interval_seconds=args.poll_interval_seconds,
+        )
     if args.command == "run":
         return command_run(root, args.issue)
 

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -25,6 +25,7 @@ from .mission_publish import (
     load_publishable_issue_label_names,
     publish_mission,
     stop_publish_for_blocking_labels,
+    upsert_review_comment,
 )
 from .mission_start import (
     MissionStartError,
@@ -375,6 +376,7 @@ def command_review(
 
     run_id = state.run_id
     now = datetime.now(timezone.utc)
+    lease_expires_at = store.format_timestamp(now + timedelta(minutes=config.mission_lease_minutes))
     try:
         store.acquire_lock(
             config=config,
@@ -398,9 +400,7 @@ def command_review(
                     phase="review",
                     review_loop_count=state.review_loop_count,
                     retryable_local_only=False,
-                    lease_expires_at=store.format_timestamp(
-                        now + timedelta(minutes=config.mission_lease_minutes)
-                    ),
+                    lease_expires_at=lease_expires_at,
                     last_result=state.last_result,
                     last_error=None,
                     last_mission=state.last_mission,
@@ -412,6 +412,20 @@ def command_review(
             return 1
 
         client = GitHubClient(root, repo=config.repo)
+
+        def update_review_comment(*, comment_lease_expires_at: str) -> None:
+            try:
+                upsert_review_comment(
+                    client=client,
+                    issue_number=state.issue_number,
+                    branch=state.branch,
+                    pr_number=state.pr_number,
+                    lease_expires_at=comment_lease_expires_at,
+                    agent_identity=config.agent_identity,
+                    run_id=run_id,
+                )
+            except MissionPublishError as error:
+                raise ReviewerError(str(error)) from error
 
         def persist_review_error(error_message: str) -> None:
             try:
@@ -440,13 +454,18 @@ def command_review(
 
         def heartbeat() -> None:
             heartbeat_now = datetime.now(timezone.utc)
+            heartbeat_lease_expires_at = store.format_timestamp(
+                heartbeat_now + timedelta(minutes=config.mission_lease_minutes)
+            )
             store.refresh_lock_heartbeat(
                 run_id=run_id,
                 agent_identity=config.agent_identity,
                 now=heartbeat_now,
             )
+            update_review_comment(comment_lease_expires_at=heartbeat_lease_expires_at)
 
         try:
+            update_review_comment(comment_lease_expires_at=lease_expires_at)
             ci_status = wait_for_ci(
                 client,
                 state.pr_number,
@@ -459,6 +478,11 @@ def command_review(
             print(f"review aborted: {error}")
             return 1
 
+        completed_at = datetime.now(timezone.utc)
+        completed_lease_expires_at = store.format_timestamp(
+            completed_at + timedelta(minutes=config.mission_lease_minutes)
+        )
+        update_review_comment(comment_lease_expires_at=completed_lease_expires_at)
         review_state = State(
             issue_number=state.issue_number,
             pr_number=state.pr_number,
@@ -468,9 +492,7 @@ def command_review(
             phase="review",
             review_loop_count=state.review_loop_count,
             retryable_local_only=False,
-            lease_expires_at=store.format_timestamp(
-                datetime.now(timezone.utc) + timedelta(minutes=config.mission_lease_minutes)
-            ),
+            lease_expires_at=completed_lease_expires_at,
             last_result=render_review_result(ci_status),
             last_error="CI polling timed out before checks completed" if ci_status.timed_out else None,
             last_mission=state.last_mission,

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -482,7 +482,6 @@ def command_review(
         completed_lease_expires_at = store.format_timestamp(
             completed_at + timedelta(minutes=config.mission_lease_minutes)
         )
-        update_review_comment(comment_lease_expires_at=completed_lease_expires_at)
         review_state = State(
             issue_number=state.issue_number,
             pr_number=state.pr_number,
@@ -514,8 +513,14 @@ def command_review(
             },
         )
         try:
+            update_review_comment(comment_lease_expires_at=completed_lease_expires_at)
             store.save_state(review_state)
+        except (ReviewerError, RuntimeError, ValueError) as error:
+            persist_review_error(str(error))
+            print(f"review aborted: {error}")
+            return 1
         except OSError as error:
+            persist_review_error(f"failed to persist CI review result: {error}")
             print(f"review aborted: failed to persist CI review result: {error}")
             return 1
 

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -58,13 +58,13 @@ def build_parser() -> argparse.ArgumentParser:
     review_parser = subparsers.add_parser("review", help="Wait for PR CI and persist review state.")
     review_parser.add_argument(
         "--timeout-seconds",
-        type=float,
+        type=non_negative_seconds,
         default=900,
         help="Maximum time to wait for CI completion.",
     )
     review_parser.add_argument(
         "--poll-interval-seconds",
-        type=float,
+        type=positive_seconds,
         default=10,
         help="Polling interval for CI status checks.",
     )
@@ -76,6 +76,20 @@ def positive_issue_number(value: str) -> int:
     if issue_number <= 0:
         raise argparse.ArgumentTypeError("issue number must be a positive integer")
     return issue_number
+
+
+def non_negative_seconds(value: str) -> float:
+    seconds = float(value)
+    if seconds < 0:
+        raise argparse.ArgumentTypeError("seconds must be non-negative")
+    return seconds
+
+
+def positive_seconds(value: str) -> float:
+    seconds = float(value)
+    if seconds <= 0:
+        raise argparse.ArgumentTypeError("seconds must be positive")
+    return seconds
 
 
 def command_init(root: Path) -> int:
@@ -345,6 +359,13 @@ def command_review(
     timeout_seconds: float,
     poll_interval_seconds: float,
 ) -> int:
+    if timeout_seconds < 0:
+        print("review aborted: timeout_seconds must be non-negative")
+        return 1
+    if poll_interval_seconds <= 0:
+        print("review aborted: poll_interval_seconds must be positive")
+        return 1
+
     store = StateStore(root)
     if not store.has_state():
         print("Shinobi is not initialized in this workspace.")

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -373,6 +373,12 @@ def command_review(
             "and run_id"
         )
         return 1
+    if state.agent_identity and state.agent_identity != config.agent_identity:
+        print(
+            "review aborted: local mission state belongs to a different agent "
+            f"({state.agent_identity})"
+        )
+        return 1
 
     run_id = state.run_id
     now = datetime.now(timezone.utc)

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -366,11 +365,14 @@ def command_review(
             f"got {state.phase}"
         )
         return 1
-    if state.issue_number is None or state.pr_number is None or not state.branch:
-        print("review aborted: local mission state requires issue_number, pr_number, and branch")
+    if state.issue_number is None or state.pr_number is None or not state.branch or not state.run_id:
+        print(
+            "review aborted: local mission state requires issue_number, pr_number, branch, "
+            "and run_id"
+        )
         return 1
 
-    run_id = uuid.uuid4().hex
+    run_id = state.run_id
     now = datetime.now(timezone.utc)
     try:
         store.acquire_lock(

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -479,7 +479,7 @@ def command_review(
             )
         else:
             print("ci_checks: none")
-        return 1 if ci_status.timed_out else 0
+        return 1 if ci_status.timed_out or ci_status.is_failed else 0
     finally:
         store.clear_lock(run_id)
 

--- a/src/shinobi/github_client.py
+++ b/src/shinobi/github_client.py
@@ -216,6 +216,7 @@ class GitHubClient:
                 "name,state,link,bucket",
             ],
             action=f"load CI status for PR #{pr_number}",
+            allowed_returncodes={0, 8},
         )
         if not isinstance(payload, list):
             raise GitHubClientError(
@@ -269,8 +270,14 @@ class GitHubClient:
         *,
         action: str,
         fields: dict[str, str] | None = None,
+        allowed_returncodes: set[int] | None = None,
     ) -> Any:
-        result = self._run_gh(args, action=action, fields=fields)
+        result = self._run_gh(
+            args,
+            action=action,
+            fields=fields,
+            allowed_returncodes=allowed_returncodes,
+        )
         try:
             return json.loads(result.stdout or "null")
         except JSONDecodeError as error:
@@ -282,6 +289,7 @@ class GitHubClient:
         *,
         action: str,
         fields: dict[str, str] | None = None,
+        allowed_returncodes: set[int] | None = None,
     ) -> subprocess.CompletedProcess[str]:
         command = ["gh", *args]
         if fields:
@@ -299,7 +307,7 @@ class GitHubClient:
         except OSError as error:
             raise GitHubClientError(f"failed to {action} with gh: {error}") from error
 
-        if result.returncode != 0:
+        if result.returncode not in (allowed_returncodes or {0}):
             stderr = result.stderr.strip()
             message = stderr or (result.stdout.strip() if result.stdout else "")
             if not message:

--- a/src/shinobi/github_client.py
+++ b/src/shinobi/github_client.py
@@ -218,10 +218,13 @@ class GitHubClient:
             action=f"load CI status for PR #{pr_number}",
             allowed_returncodes={0, 1, 8},
         )
-        if result.returncode == 1 and "no checks reported" in result.stderr:
+        output = result.stdout.strip()
+        error_output = result.stderr.strip()
+        combined_output = f"{output}\n{error_output}".lower()
+        if result.returncode == 1 and "no checks reported" in combined_output:
             return []
-        if result.returncode == 1:
-            message = result.stderr.strip() or result.stdout.strip() or "gh exited with status 1"
+        if result.returncode == 1 and not output:
+            message = error_output or "gh exited with status 1"
             raise GitHubClientError(
                 f"failed to load CI status for PR #{pr_number} with gh: {message}"
             )

--- a/src/shinobi/github_client.py
+++ b/src/shinobi/github_client.py
@@ -207,7 +207,7 @@ class GitHubClient:
         return [pr for pr in payload if isinstance(pr, dict)]
 
     def get_ci_status(self, pr_number: int) -> list[dict[str, Any]]:
-        payload = self._run_gh_json(
+        result = self._run_gh(
             [
                 "pr",
                 "checks",
@@ -216,8 +216,20 @@ class GitHubClient:
                 "name,state,link,bucket",
             ],
             action=f"load CI status for PR #{pr_number}",
-            allowed_returncodes={0, 8},
+            allowed_returncodes={0, 1, 8},
         )
+        if result.returncode == 1 and "no checks reported" in result.stderr:
+            return []
+        if result.returncode == 1:
+            message = result.stderr.strip() or result.stdout.strip() or "gh exited with status 1"
+            raise GitHubClientError(f"failed to load CI status for PR #{pr_number} with gh: {message}")
+
+        try:
+            payload = json.loads(result.stdout or "null")
+        except JSONDecodeError as error:
+            raise GitHubClientError(
+                f"failed to parse GitHub response while trying to load CI status for PR #{pr_number}"
+            ) from error
         if not isinstance(payload, list):
             raise GitHubClientError(
                 f"failed to parse CI status for PR #{pr_number}: expected list payload"

--- a/src/shinobi/github_client.py
+++ b/src/shinobi/github_client.py
@@ -222,7 +222,9 @@ class GitHubClient:
             return []
         if result.returncode == 1:
             message = result.stderr.strip() or result.stdout.strip() or "gh exited with status 1"
-            raise GitHubClientError(f"failed to load CI status for PR #{pr_number} with gh: {message}")
+            raise GitHubClientError(
+                f"failed to load CI status for PR #{pr_number} with gh: {message}"
+            )
 
         try:
             payload = json.loads(result.stdout or "null")

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -720,6 +720,40 @@ def upsert_publish_comment(
         ) from error
 
 
+def upsert_review_comment(
+    *,
+    client: GitHubClient,
+    issue_number: int,
+    branch: str,
+    pr_number: int,
+    lease_expires_at: str,
+    agent_identity: str,
+    run_id: str,
+) -> None:
+    body = render_review_comment(
+        issue_number=issue_number,
+        branch=branch,
+        pr_number=pr_number,
+        lease_expires_at=lease_expires_at,
+        agent_identity=agent_identity,
+        run_id=run_id,
+    )
+    try:
+        comment = find_mission_state_comment(
+            client.list_issue_comments(issue_number),
+            issue_number=issue_number,
+            branch=branch,
+        )
+        if comment is None:
+            client.create_issue_comment(issue_number, body)
+            return
+        client.update_issue_comment(int(comment["id"]), body)
+    except (GitHubClientError, KeyError, TypeError, ValueError) as error:
+        raise MissionPublishError(
+            f"failed to upsert review mission-state comment for issue #{issue_number}: {error}"
+        ) from error
+
+
 def upsert_publish_failure_comment(
     *,
     client: GitHubClient,
@@ -839,4 +873,29 @@ def render_publish_failure_state_comment(
         f"任務 #{issue_number} の publish 中に人手対応が必要になりました。\n"
         f"- pr: #{pr_number}\n"
         f"- reason: {reason}\n"
+    )
+
+
+def render_review_comment(
+    *,
+    issue_number: int,
+    branch: str,
+    pr_number: int,
+    lease_expires_at: str,
+    agent_identity: str,
+    run_id: str,
+) -> str:
+    return (
+        "<!-- shinobi:mission-state\n"
+        f"issue: {issue_number}\n"
+        f"branch: {branch}\n"
+        "phase: review\n"
+        f"pr: {pr_number}\n"
+        f"lease_expires_at: {lease_expires_at}\n"
+        f"agent_identity: {agent_identity}\n"
+        f"run_id: {run_id}\n"
+        "-->\n"
+        "Shinobi Review\n\n"
+        f"任務 #{issue_number} の review を継続しています。\n"
+        f"- pr: #{pr_number}\n"
     )

--- a/src/shinobi/models.py
+++ b/src/shinobi/models.py
@@ -209,3 +209,42 @@ class ReviewDecision:
     @property
     def can_continue(self) -> bool:
         return not self.should_stop
+
+
+@dataclass(frozen=True)
+class PullRequestCheck:
+    name: str
+    state: str
+    bucket: str
+    link: str | None = None
+
+    @property
+    def is_pending(self) -> bool:
+        return self.bucket == "pending"
+
+    @property
+    def is_successful(self) -> bool:
+        return self.bucket in {"pass", "skipping"}
+
+    @property
+    def is_failed(self) -> bool:
+        return self.bucket in {"fail", "cancel"}
+
+
+@dataclass(frozen=True)
+class CIStatus:
+    checks: List[PullRequestCheck]
+    status: str
+    timed_out: bool = False
+
+    @property
+    def is_pending(self) -> bool:
+        return self.status == "pending"
+
+    @property
+    def is_successful(self) -> bool:
+        return self.status == "success"
+
+    @property
+    def is_failed(self) -> bool:
+        return self.status == "failure"

--- a/src/shinobi/reviewer.py
+++ b/src/shinobi/reviewer.py
@@ -164,6 +164,8 @@ def parse_pull_request_check(payload: dict[str, Any]) -> PullRequestCheck:
 
 
 def resolve_ci_status(checks: list[PullRequestCheck]) -> str:
+    if not checks:
+        return "pending"
     if any(check.is_failed for check in checks):
         return "failure"
     if any(check.is_pending for check in checks):

--- a/src/shinobi/reviewer.py
+++ b/src/shinobi/reviewer.py
@@ -15,17 +15,24 @@ class ReviewerError(RuntimeError):
 
 
 PENDING_CHECK_STATES = {
-    "action_required",
     "expected",
     "in_progress",
     "pending",
     "queued",
     "requested",
-    "startup_failure",
     "waiting",
 }
 SUCCESS_CHECK_STATES = {"neutral", "success", "skipped"}
-FAILURE_CHECK_STATES = {"cancelled", "failure", "error", "timed_out"}
+FAILURE_CHECK_STATES = {
+    "action_required",
+    "cancel",
+    "cancelled",
+    "error",
+    "failure",
+    "stale",
+    "startup_failure",
+    "timed_out",
+}
 
 
 def collect_diff_stats(root: Path, *, base_ref: str) -> DiffStats:

--- a/src/shinobi/reviewer.py
+++ b/src/shinobi/reviewer.py
@@ -1,14 +1,31 @@
 from __future__ import annotations
 
+import time
+from collections.abc import Callable
 import subprocess
 from pathlib import Path
 from typing import Any
 
-from .models import Config, DiffStats, ReviewDecision, State
+from .github_client import GitHubClient, GitHubClientError
+from .models import CIStatus, Config, DiffStats, PullRequestCheck, ReviewDecision, State
 
 
 class ReviewerError(RuntimeError):
     """Raised when review inputs cannot be gathered safely."""
+
+
+PENDING_CHECK_STATES = {
+    "action_required",
+    "expected",
+    "in_progress",
+    "pending",
+    "queued",
+    "requested",
+    "startup_failure",
+    "waiting",
+}
+SUCCESS_CHECK_STATES = {"neutral", "success", "skipped"}
+FAILURE_CHECK_STATES = {"cancelled", "failure", "error", "timed_out"}
 
 
 def collect_diff_stats(root: Path, *, base_ref: str) -> DiffStats:
@@ -87,6 +104,86 @@ def evaluate_review(
         )
 
     return ReviewDecision(should_stop=bool(reasons), reasons=reasons)
+
+
+def collect_ci_status(client: GitHubClient, pr_number: int) -> CIStatus:
+    try:
+        payload = client.get_ci_status(pr_number)
+    except GitHubClientError as error:
+        raise ReviewerError(f"failed to load CI status for PR #{pr_number}: {error}") from error
+
+    checks = [parse_pull_request_check(item) for item in payload if isinstance(item, dict)]
+    return CIStatus(checks=checks, status=resolve_ci_status(checks))
+
+
+def wait_for_ci(
+    client: GitHubClient,
+    pr_number: int,
+    *,
+    timeout_seconds: float = 900,
+    poll_interval_seconds: float = 10,
+    heartbeat: Callable[[], None] | None = None,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> CIStatus:
+    if timeout_seconds < 0:
+        raise ValueError("timeout_seconds must be non-negative")
+    if poll_interval_seconds <= 0:
+        raise ValueError("poll_interval_seconds must be positive")
+
+    deadline = monotonic() + timeout_seconds
+
+    while True:
+        if heartbeat is not None:
+            heartbeat()
+
+        status = collect_ci_status(client, pr_number)
+        if not status.is_pending:
+            return status
+
+        now = monotonic()
+        if now >= deadline:
+            return CIStatus(checks=status.checks, status=status.status, timed_out=True)
+
+        sleep(min(poll_interval_seconds, deadline - now))
+
+
+def parse_pull_request_check(payload: dict[str, Any]) -> PullRequestCheck:
+    state = str(payload.get("state", "pending"))
+    bucket = normalize_check_bucket(
+        str(payload.get("bucket", "")),
+        state,
+    )
+    link = payload.get("link")
+    return PullRequestCheck(
+        name=str(payload.get("name", "(unnamed check)")),
+        state=state,
+        bucket=bucket,
+        link=str(link) if isinstance(link, str) else None,
+    )
+
+
+def resolve_ci_status(checks: list[PullRequestCheck]) -> str:
+    if any(check.is_failed for check in checks):
+        return "failure"
+    if any(check.is_pending for check in checks):
+        return "pending"
+    return "success"
+
+
+def normalize_check_bucket(bucket: str, state: str) -> str:
+    normalized_bucket = bucket.strip().lower()
+    if normalized_bucket in {"pass", "pending", "fail", "cancel", "skipping"}:
+        return normalized_bucket
+
+    normalized_state = state.strip().lower()
+    if normalized_state in FAILURE_CHECK_STATES:
+        return "fail"
+    if normalized_state in SUCCESS_CHECK_STATES:
+        return "pass"
+    if normalized_state in PENDING_CHECK_STATES:
+        return "pending"
+    return "pending"
 
 
 def issue_label_names(issue: dict[str, Any]) -> set[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5472,6 +5472,40 @@ class GitHubClientTest(unittest.TestCase):
                 ):
                     client.get_issue(6)
 
+    def test_get_ci_status_accepts_pending_exit_code_from_gh_pr_checks(self) -> None:
+        result = subprocess.CompletedProcess(
+            args=["gh", "pr", "checks", "44"],
+            returncode=8,
+            stdout=json.dumps(
+                [
+                    {
+                        "name": "test",
+                        "state": "IN_PROGRESS",
+                        "bucket": "pending",
+                        "link": "https://ci/test",
+                    }
+                ]
+            ),
+            stderr="",
+        )
+
+        with patch("shinobi.github_client.discover_repo_slug", return_value="owner/repo"):
+            with patch("shinobi.github_client.subprocess.run", return_value=result):
+                client = GitHubClient(Path("/tmp/repo"))
+                status = client.get_ci_status(44)
+
+        self.assertEqual(
+            status,
+            [
+                {
+                    "name": "test",
+                    "state": "IN_PROGRESS",
+                    "bucket": "pending",
+                    "link": "https://ci/test",
+                }
+            ],
+        )
+
     def test_update_issue_labels_runs_add_then_remove_operations(self) -> None:
         responses = [
             subprocess.CompletedProcess(args=["gh", "issue", "edit", "6"], returncode=0, stdout="", stderr=""),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6275,6 +6275,19 @@ class ReviewerTest(unittest.TestCase):
         self.assertEqual(status, CIStatus(checks=[], status="pending"))
         self.assertTrue(status.is_pending)
 
+    def test_collect_ci_status_falls_back_to_failure_for_terminal_states(self) -> None:
+        client = Mock()
+        client.get_ci_status.return_value = [
+            {"name": "deploy", "state": "ACTION_REQUIRED"},
+            {"name": "build", "state": "STARTUP_FAILURE"},
+        ]
+
+        status = collect_ci_status(client, 51)
+
+        self.assertEqual(status.status, "failure")
+        self.assertTrue(status.is_failed)
+        self.assertEqual([check.bucket for check in status.checks], ["fail", "fail"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -653,6 +653,60 @@ class CliTest(unittest.TestCase):
             self.assertTrue(saved_state.extra["ci_status"]["timed_out"])
             self.assertIsNone(store.load_lock())
 
+    def test_review_failed_ci_returns_nonzero_and_persists_failure_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            issue_number=33,
+                            pr_number=44,
+                            branch="feature/issue-33-review-ci",
+                            agent_identity=config.agent_identity,
+                            run_id="publish-run",
+                            phase="publish",
+                            last_result="published",
+                        )
+                    )
+
+                    output = io.StringIO()
+                    with patch("shinobi.cli.GitHubClient", return_value=Mock()):
+                        with patch(
+                            "shinobi.cli.wait_for_ci",
+                            return_value=CIStatus(
+                                checks=[
+                                    PullRequestCheck(
+                                        name="test",
+                                        state="FAILURE",
+                                        bucket="fail",
+                                    )
+                                ],
+                                status="failure",
+                            ),
+                        ):
+                            with redirect_stdout(output):
+                                exit_code = cli.main(["review"])
+
+            self.assertEqual(exit_code, 1)
+            rendered = output.getvalue()
+            self.assertIn("ci_status: failure", rendered)
+            self.assertIn("ci_timed_out: False", rendered)
+
+            saved_state = store.load_state()
+            self.assertEqual(saved_state.phase, "review")
+            self.assertEqual(saved_state.last_result, "ci-failure")
+            self.assertIsNone(saved_state.last_error)
+            self.assertEqual(saved_state.extra["ci_status"]["status"], "failure")
+            self.assertFalse(saved_state.extra["ci_status"]["timed_out"])
+            self.assertIsNone(store.load_lock())
+
     def test_init_preserves_state_agent_identity_when_config_is_recreated(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -876,6 +876,83 @@ class CliTest(unittest.TestCase):
             self.assertEqual(saved_state.last_error, "api unavailable")
             self.assertIsNone(store.load_lock())
 
+    def test_review_persists_last_error_when_completion_comment_update_aborts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            issue_number=33,
+                            pr_number=44,
+                            branch="feature/issue-33-review-ci",
+                            agent_identity=config.agent_identity,
+                            run_id="publish-run",
+                            phase="publish",
+                            last_result="published",
+                        )
+                    )
+
+                    output = io.StringIO()
+                    client = Mock()
+                    client.list_issue_comments.return_value = [
+                        {
+                            "id": 9001,
+                            "body": (
+                                "<!-- shinobi:mission-state\n"
+                                "issue: 33\n"
+                                "branch: feature/issue-33-review-ci\n"
+                                "phase: publish\n"
+                                "pr: 44\n"
+                                "-->\n"
+                            ),
+                        }
+                    ]
+                    client.update_issue_comment.side_effect = [
+                        None,
+                        GitHubClientError("failed to write review heartbeat comment"),
+                    ]
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
+                        with patch(
+                            "shinobi.cli.wait_for_ci",
+                            return_value=CIStatus(
+                                checks=[
+                                    PullRequestCheck(
+                                        name="test",
+                                        state="SUCCESS",
+                                        bucket="pass",
+                                    )
+                                ],
+                                status="success",
+                            ),
+                        ):
+                            with redirect_stdout(output):
+                                exit_code = cli.main(["review"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn(
+                "review aborted: failed to upsert review mission-state comment for issue #33: "
+                "failed to write review heartbeat comment",
+                output.getvalue(),
+            )
+
+            saved_state = store.load_state()
+            self.assertEqual(saved_state.phase, "review")
+            self.assertEqual(saved_state.run_id, "publish-run")
+            self.assertEqual(saved_state.last_result, "review-error")
+            self.assertEqual(
+                saved_state.last_error,
+                "failed to upsert review mission-state comment for issue #33: "
+                "failed to write review heartbeat comment",
+            )
+            self.assertIsNone(store.load_lock())
+
     def test_review_aborts_when_active_mission_lacks_run_id(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -592,6 +592,7 @@ class CliTest(unittest.TestCase):
 
             saved_state = store.load_state()
             self.assertEqual(saved_state.phase, "review")
+            self.assertEqual(saved_state.run_id, "publish-run")
             self.assertEqual(saved_state.last_result, "ci-success")
             self.assertIsNone(saved_state.last_error)
             self.assertEqual(saved_state.extra["ci_status"]["status"], "success")
@@ -648,6 +649,7 @@ class CliTest(unittest.TestCase):
 
             saved_state = store.load_state()
             self.assertEqual(saved_state.phase, "review")
+            self.assertEqual(saved_state.run_id, "publish-run")
             self.assertEqual(saved_state.last_result, "ci-timeout")
             self.assertEqual(saved_state.last_error, "CI polling timed out before checks completed")
             self.assertTrue(saved_state.extra["ci_status"]["timed_out"])
@@ -701,6 +703,7 @@ class CliTest(unittest.TestCase):
 
             saved_state = store.load_state()
             self.assertEqual(saved_state.phase, "review")
+            self.assertEqual(saved_state.run_id, "publish-run")
             self.assertEqual(saved_state.last_result, "ci-failure")
             self.assertIsNone(saved_state.last_error)
             self.assertEqual(saved_state.extra["ci_status"]["status"], "failure")
@@ -744,9 +747,43 @@ class CliTest(unittest.TestCase):
 
             saved_state = store.load_state()
             self.assertEqual(saved_state.phase, "review")
+            self.assertEqual(saved_state.run_id, "publish-run")
             self.assertEqual(saved_state.last_result, "review-error")
             self.assertEqual(saved_state.last_error, "api unavailable")
             self.assertIsNone(store.load_lock())
+
+    def test_review_aborts_when_active_mission_lacks_run_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            issue_number=33,
+                            pr_number=44,
+                            branch="feature/issue-33-review-ci",
+                            agent_identity=config.agent_identity,
+                            run_id=None,
+                            phase="publish",
+                        )
+                    )
+
+                    output = io.StringIO()
+                    with redirect_stdout(output):
+                        exit_code = cli.main(["review"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn(
+                "review aborted: local mission state requires issue_number, pr_number, branch, "
+                "and run_id",
+                output.getvalue(),
+            )
 
     def test_init_preserves_state_agent_identity_when_config_is_recreated(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -5993,6 +6030,15 @@ class ReviewerTest(unittest.TestCase):
                 timed_out=True,
             ),
         )
+
+    def test_collect_ci_status_treats_missing_checks_as_pending(self) -> None:
+        client = Mock()
+        client.get_ci_status.return_value = []
+
+        status = collect_ci_status(client, 51)
+
+        self.assertEqual(status, CIStatus(checks=[], status="pending"))
+        self.assertTrue(status.is_pending)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5506,6 +5506,21 @@ class GitHubClientTest(unittest.TestCase):
             ],
         )
 
+    def test_get_ci_status_treats_no_checks_reported_as_empty_status(self) -> None:
+        result = subprocess.CompletedProcess(
+            args=["gh", "pr", "checks", "44"],
+            returncode=1,
+            stdout="",
+            stderr="no checks reported on the 'feature/test' branch\n",
+        )
+
+        with patch("shinobi.github_client.discover_repo_slug", return_value="owner/repo"):
+            with patch("shinobi.github_client.subprocess.run", return_value=result):
+                client = GitHubClient(Path("/tmp/repo"))
+                status = client.get_ci_status(44)
+
+        self.assertEqual(status, [])
+
     def test_update_issue_labels_runs_add_then_remove_operations(self) -> None:
         responses = [
             subprocess.CompletedProcess(args=["gh", "issue", "edit", "6"], returncode=0, stdout="", stderr=""),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5598,6 +5598,40 @@ class GitHubClientTest(unittest.TestCase):
 
         self.assertEqual(status, [])
 
+    def test_get_ci_status_accepts_failed_checks_from_exit_code_one(self) -> None:
+        result = subprocess.CompletedProcess(
+            args=["gh", "pr", "checks", "44"],
+            returncode=1,
+            stdout=json.dumps(
+                [
+                    {
+                        "name": "test",
+                        "state": "FAILURE",
+                        "bucket": "fail",
+                        "link": "https://ci/test",
+                    }
+                ]
+            ),
+            stderr="",
+        )
+
+        with patch("shinobi.github_client.discover_repo_slug", return_value="owner/repo"):
+            with patch("shinobi.github_client.subprocess.run", return_value=result):
+                client = GitHubClient(Path("/tmp/repo"))
+                status = client.get_ci_status(44)
+
+        self.assertEqual(
+            status,
+            [
+                {
+                    "name": "test",
+                    "state": "FAILURE",
+                    "bucket": "fail",
+                    "link": "https://ci/test",
+                }
+            ],
+        )
+
     def test_update_issue_labels_runs_add_then_remove_operations(self) -> None:
         responses = [
             subprocess.CompletedProcess(args=["gh", "issue", "edit", "6"], returncode=0, stdout="", stderr=""),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -527,6 +527,132 @@ class CliTest(unittest.TestCase):
             self.assertFalse(store.paths.decisions_path.exists())
             self.assertFalse(store.paths.lock_path.exists())
 
+    def test_review_waits_for_ci_and_persists_review_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            issue_number=33,
+                            pr_number=44,
+                            branch="feature/issue-33-review-ci",
+                            agent_identity=config.agent_identity,
+                            run_id="publish-run",
+                            phase="publish",
+                            last_result="published",
+                        )
+                    )
+
+                    client = Mock()
+                    output = io.StringIO()
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
+                        with patch(
+                            "shinobi.cli.wait_for_ci",
+                            return_value=CIStatus(
+                                checks=[
+                                    PullRequestCheck(
+                                        name="test",
+                                        state="SUCCESS",
+                                        bucket="pass",
+                                    )
+                                ],
+                                status="success",
+                            ),
+                        ) as wait_for_ci_mock:
+                            with redirect_stdout(output):
+                                exit_code = cli.main(
+                                    [
+                                        "review",
+                                        "--timeout-seconds",
+                                        "30",
+                                        "--poll-interval-seconds",
+                                        "5",
+                                    ]
+                                )
+
+            self.assertEqual(exit_code, 0)
+            rendered = output.getvalue()
+            self.assertIn("review_issue: #33", rendered)
+            self.assertIn("review_pr: #44", rendered)
+            self.assertIn("ci_status: success", rendered)
+            self.assertIn("ci_checks: test=pass", rendered)
+            wait_for_ci_mock.assert_called_once()
+            self.assertIs(wait_for_ci_mock.call_args.args[0], client)
+            self.assertEqual(wait_for_ci_mock.call_args.args[1], 44)
+            self.assertEqual(wait_for_ci_mock.call_args.kwargs["timeout_seconds"], 30.0)
+            self.assertEqual(wait_for_ci_mock.call_args.kwargs["poll_interval_seconds"], 5.0)
+            self.assertIsNotNone(wait_for_ci_mock.call_args.kwargs["heartbeat"])
+
+            saved_state = store.load_state()
+            self.assertEqual(saved_state.phase, "review")
+            self.assertEqual(saved_state.last_result, "ci-success")
+            self.assertIsNone(saved_state.last_error)
+            self.assertEqual(saved_state.extra["ci_status"]["status"], "success")
+            self.assertFalse(saved_state.extra["ci_status"]["timed_out"])
+            self.assertEqual(saved_state.extra["ci_status"]["checks"][0]["name"], "test")
+            self.assertIsNone(store.load_lock())
+
+    def test_review_timeout_returns_nonzero_and_persists_pending_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            issue_number=33,
+                            pr_number=44,
+                            branch="feature/issue-33-review-ci",
+                            agent_identity=config.agent_identity,
+                            run_id="publish-run",
+                            phase="publish",
+                            last_result="published",
+                        )
+                    )
+
+                    output = io.StringIO()
+                    with patch("shinobi.cli.GitHubClient", return_value=Mock()):
+                        with patch(
+                            "shinobi.cli.wait_for_ci",
+                            return_value=CIStatus(
+                                checks=[
+                                    PullRequestCheck(
+                                        name="test",
+                                        state="QUEUED",
+                                        bucket="pending",
+                                    )
+                                ],
+                                status="pending",
+                                timed_out=True,
+                            ),
+                        ):
+                            with redirect_stdout(output):
+                                exit_code = cli.main(["review"])
+
+            self.assertEqual(exit_code, 1)
+            rendered = output.getvalue()
+            self.assertIn("ci_status: pending", rendered)
+            self.assertIn("ci_timed_out: True", rendered)
+
+            saved_state = store.load_state()
+            self.assertEqual(saved_state.phase, "review")
+            self.assertEqual(saved_state.last_result, "ci-timeout")
+            self.assertEqual(saved_state.last_error, "CI polling timed out before checks completed")
+            self.assertTrue(saved_state.extra["ci_status"]["timed_out"])
+            self.assertIsNone(store.load_lock())
+
     def test_init_preserves_state_agent_identity_when_config_is_recreated(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -986,6 +986,42 @@ class CliTest(unittest.TestCase):
                 output.getvalue(),
             )
 
+    def test_review_aborts_when_active_mission_belongs_to_different_agent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            issue_number=33,
+                            pr_number=44,
+                            branch="feature/issue-33-review-ci",
+                            agent_identity="other-agent",
+                            run_id="publish-run",
+                            phase="publish",
+                        )
+                    )
+
+                    client = Mock()
+                    output = io.StringIO()
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
+                        with redirect_stdout(output):
+                            exit_code = cli.main(["review"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn(
+                "review aborted: local mission state belongs to a different agent (other-agent)",
+                output.getvalue(),
+            )
+            client.assert_not_called()
+            self.assertIsNone(store.load_lock())
+
     def test_init_preserves_state_agent_identity_when_config_is_recreated(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1022,6 +1022,47 @@ class CliTest(unittest.TestCase):
             client.assert_not_called()
             self.assertIsNone(store.load_lock())
 
+    def test_review_rejects_invalid_poll_interval_before_side_effects(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    original_state = State(
+                        issue_number=33,
+                        pr_number=44,
+                        branch="feature/issue-33-review-ci",
+                        agent_identity=config.agent_identity,
+                        run_id="publish-run",
+                        phase="publish",
+                        last_result="published",
+                    )
+                    store.save_state(original_state)
+
+                    output = io.StringIO()
+                    client = Mock()
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
+                        with redirect_stdout(output):
+                            exit_code = cli.command_review(
+                                root,
+                                timeout_seconds=30,
+                                poll_interval_seconds=0,
+                            )
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn(
+                "review aborted: poll_interval_seconds must be positive",
+                output.getvalue(),
+            )
+            self.assertEqual(store.load_state(), original_state)
+            client.assert_not_called()
+            self.assertIsNone(store.load_lock())
+
     def test_init_preserves_state_agent_identity_when_config_is_recreated(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -707,6 +707,47 @@ class CliTest(unittest.TestCase):
             self.assertFalse(saved_state.extra["ci_status"]["timed_out"])
             self.assertIsNone(store.load_lock())
 
+    def test_review_persists_last_error_when_ci_polling_aborts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            issue_number=33,
+                            pr_number=44,
+                            branch="feature/issue-33-review-ci",
+                            agent_identity=config.agent_identity,
+                            run_id="publish-run",
+                            phase="publish",
+                            last_result="published",
+                        )
+                    )
+
+                    output = io.StringIO()
+                    with patch("shinobi.cli.GitHubClient", return_value=Mock()):
+                        with patch(
+                            "shinobi.cli.wait_for_ci",
+                            side_effect=ReviewerError("api unavailable"),
+                        ):
+                            with redirect_stdout(output):
+                                exit_code = cli.main(["review"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn("review aborted: api unavailable", output.getvalue())
+
+            saved_state = store.load_state()
+            self.assertEqual(saved_state.phase, "review")
+            self.assertEqual(saved_state.last_result, "review-error")
+            self.assertEqual(saved_state.last_error, "api unavailable")
+            self.assertIsNone(store.load_lock())
+
     def test_init_preserves_state_agent_identity_when_config_is_recreated(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -552,6 +552,19 @@ class CliTest(unittest.TestCase):
 
                     client = Mock()
                     output = io.StringIO()
+                    client.list_issue_comments.return_value = [
+                        {
+                            "id": 9001,
+                            "body": (
+                                "<!-- shinobi:mission-state\n"
+                                "issue: 33\n"
+                                "branch: feature/issue-33-review-ci\n"
+                                "phase: publish\n"
+                                "pr: 44\n"
+                                "-->\n"
+                            ),
+                        }
+                    ]
                     with patch("shinobi.cli.GitHubClient", return_value=client):
                         with patch(
                             "shinobi.cli.wait_for_ci",
@@ -589,6 +602,9 @@ class CliTest(unittest.TestCase):
             self.assertEqual(wait_for_ci_mock.call_args.kwargs["timeout_seconds"], 30.0)
             self.assertEqual(wait_for_ci_mock.call_args.kwargs["poll_interval_seconds"], 5.0)
             self.assertIsNotNone(wait_for_ci_mock.call_args.kwargs["heartbeat"])
+            self.assertEqual(client.update_issue_comment.call_count, 2)
+            self.assertIn("phase: review", client.update_issue_comment.call_args_list[0].args[1])
+            self.assertIn("pr: 44", client.update_issue_comment.call_args_list[0].args[1])
 
             saved_state = store.load_state()
             self.assertEqual(saved_state.phase, "review")
@@ -624,7 +640,21 @@ class CliTest(unittest.TestCase):
                     )
 
                     output = io.StringIO()
-                    with patch("shinobi.cli.GitHubClient", return_value=Mock()):
+                    client = Mock()
+                    client.list_issue_comments.return_value = [
+                        {
+                            "id": 9001,
+                            "body": (
+                                "<!-- shinobi:mission-state\n"
+                                "issue: 33\n"
+                                "branch: feature/issue-33-review-ci\n"
+                                "phase: publish\n"
+                                "pr: 44\n"
+                                "-->\n"
+                            ),
+                        }
+                    ]
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
                         with patch(
                             "shinobi.cli.wait_for_ci",
                             return_value=CIStatus(
@@ -655,6 +685,72 @@ class CliTest(unittest.TestCase):
             self.assertTrue(saved_state.extra["ci_status"]["timed_out"])
             self.assertIsNone(store.load_lock())
 
+    def test_review_heartbeat_updates_mission_state_comment_during_polling(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            issue_number=33,
+                            pr_number=44,
+                            branch="feature/issue-33-review-ci",
+                            agent_identity=config.agent_identity,
+                            run_id="publish-run",
+                            phase="publish",
+                            last_result="published",
+                        )
+                    )
+
+                    client = Mock()
+                    client.list_issue_comments.return_value = [
+                        {
+                            "id": 9001,
+                            "body": (
+                                "<!-- shinobi:mission-state\n"
+                                "issue: 33\n"
+                                "branch: feature/issue-33-review-ci\n"
+                                "phase: publish\n"
+                                "pr: 44\n"
+                                "-->\n"
+                            ),
+                        }
+                    ]
+
+                    def wait_for_ci_side_effect(*_args, **kwargs):
+                        kwargs["heartbeat"]()
+                        return CIStatus(
+                            checks=[
+                                PullRequestCheck(
+                                    name="test",
+                                    state="SUCCESS",
+                                    bucket="pass",
+                                )
+                            ],
+                            status="success",
+                        )
+
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
+                        with patch(
+                            "shinobi.cli.wait_for_ci",
+                            side_effect=wait_for_ci_side_effect,
+                        ):
+                            with redirect_stdout(io.StringIO()):
+                                exit_code = cli.main(["review"])
+
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(client.update_issue_comment.call_count, 3)
+            for call in client.update_issue_comment.call_args_list:
+                self.assertIn("phase: review", call.args[1])
+                self.assertIn("pr: 44", call.args[1])
+            self.assertIsNone(store.load_lock())
+
     def test_review_failed_ci_returns_nonzero_and_persists_failure_result(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)
@@ -679,7 +775,21 @@ class CliTest(unittest.TestCase):
                     )
 
                     output = io.StringIO()
-                    with patch("shinobi.cli.GitHubClient", return_value=Mock()):
+                    client = Mock()
+                    client.list_issue_comments.return_value = [
+                        {
+                            "id": 9001,
+                            "body": (
+                                "<!-- shinobi:mission-state\n"
+                                "issue: 33\n"
+                                "branch: feature/issue-33-review-ci\n"
+                                "phase: publish\n"
+                                "pr: 44\n"
+                                "-->\n"
+                            ),
+                        }
+                    ]
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
                         with patch(
                             "shinobi.cli.wait_for_ci",
                             return_value=CIStatus(
@@ -734,7 +844,21 @@ class CliTest(unittest.TestCase):
                     )
 
                     output = io.StringIO()
-                    with patch("shinobi.cli.GitHubClient", return_value=Mock()):
+                    client = Mock()
+                    client.list_issue_comments.return_value = [
+                        {
+                            "id": 9001,
+                            "body": (
+                                "<!-- shinobi:mission-state\n"
+                                "issue: 33\n"
+                                "branch: feature/issue-33-review-ci\n"
+                                "phase: publish\n"
+                                "pr: 44\n"
+                                "-->\n"
+                            ),
+                        }
+                    ]
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
                         with patch(
                             "shinobi.cli.wait_for_ci",
                             side_effect=ReviewerError("api unavailable"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,16 +47,25 @@ from shinobi.mission_start import (
     start_mission,
 )
 from shinobi.models import (
+    CIStatus,
     Config,
     DiffStats,
     ExecutionResult,
     MissionSummary,
+    PullRequestCheck,
     ReviewDecision,
     StopDecision,
     State,
     VerificationCommandResult,
 )
-from shinobi.reviewer import ReviewerError, collect_diff_stats, evaluate_review, parse_numstat
+from shinobi.reviewer import (
+    ReviewerError,
+    collect_ci_status,
+    collect_diff_stats,
+    evaluate_review,
+    parse_numstat,
+    wait_for_ci,
+)
 from shinobi.state_store import StateStore
 
 
@@ -5636,6 +5645,132 @@ class ReviewerTest(unittest.TestCase):
                 "total changed lines 27 exceed max_lines_changed 20",
                 "review loop count 2 reached max_review_loops 2",
             ],
+        )
+
+    def test_collect_ci_status_classifies_checks(self) -> None:
+        client = Mock()
+        client.get_ci_status.return_value = [
+            {"name": "lint", "state": "SUCCESS", "bucket": "pass", "link": "https://ci/lint"},
+            {"name": "test", "state": "IN_PROGRESS", "bucket": "pending"},
+        ]
+
+        status = collect_ci_status(client, 51)
+
+        self.assertEqual(
+            status,
+            CIStatus(
+                checks=[
+                    PullRequestCheck(
+                        name="lint",
+                        state="SUCCESS",
+                        bucket="pass",
+                        link="https://ci/lint",
+                    ),
+                    PullRequestCheck(
+                        name="test",
+                        state="IN_PROGRESS",
+                        bucket="pending",
+                        link=None,
+                    ),
+                ],
+                status="pending",
+            ),
+        )
+        self.assertTrue(status.is_pending)
+
+    def test_collect_ci_status_wraps_github_errors(self) -> None:
+        client = Mock()
+        client.get_ci_status.side_effect = GitHubClientError("api unavailable")
+
+        with self.assertRaisesRegex(
+            ReviewerError,
+            "failed to load CI status for PR #51: api unavailable",
+        ):
+            collect_ci_status(client, 51)
+
+    def test_wait_for_ci_polls_until_success_and_calls_heartbeat(self) -> None:
+        client = Mock()
+        client.get_ci_status.side_effect = [
+            [{"name": "test", "state": "IN_PROGRESS", "bucket": "pending"}],
+            [{"name": "test", "state": "SUCCESS", "bucket": "pass"}],
+        ]
+        heartbeats: list[str] = []
+        slept: list[float] = []
+        clock = {"now": 0.0}
+
+        def heartbeat() -> None:
+            heartbeats.append("tick")
+
+        def monotonic() -> float:
+            return clock["now"]
+
+        def sleep(seconds: float) -> None:
+            slept.append(seconds)
+            clock["now"] += seconds
+
+        status = wait_for_ci(
+            client,
+            51,
+            timeout_seconds=30,
+            poll_interval_seconds=5,
+            heartbeat=heartbeat,
+            monotonic=monotonic,
+            sleep=sleep,
+        )
+
+        self.assertEqual(
+            status,
+            CIStatus(
+                checks=[
+                    PullRequestCheck(
+                        name="test",
+                        state="SUCCESS",
+                        bucket="pass",
+                        link=None,
+                    )
+                ],
+                status="success",
+            ),
+        )
+        self.assertEqual(heartbeats, ["tick", "tick"])
+        self.assertEqual(slept, [5])
+
+    def test_wait_for_ci_returns_timed_out_pending_result(self) -> None:
+        client = Mock()
+        client.get_ci_status.return_value = [
+            {"name": "test", "state": "QUEUED", "bucket": "pending"}
+        ]
+        clock = {"now": 0.0}
+
+        def monotonic() -> float:
+            return clock["now"]
+
+        def sleep(seconds: float) -> None:
+            clock["now"] += seconds
+
+        status = wait_for_ci(
+            client,
+            51,
+            timeout_seconds=4,
+            poll_interval_seconds=2,
+            monotonic=monotonic,
+            sleep=sleep,
+        )
+
+        self.assertEqual(
+            status,
+            CIStatus(
+                checks=[
+                    PullRequestCheck(
+                        name="test",
+                        state="QUEUED",
+                        bucket="pending",
+                        link=None,
+                    )
+                ],
+                status="pending",
+                timed_out=True,
+            ),
         )
 
 


### PR DESCRIPTION
## Summary
- add structured CI check and aggregate status models for the review phase
- implement reviewer-side CI polling with timeout handling and injectable heartbeat hooks
- cover status classification, GitHub failure wrapping, polling success, and timeout paths in tests

## Testing
- python3 -m unittest tests.test_cli.ReviewerTest
- python3 -m unittest tests.test_cli
- env PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m compileall src tests

Refs #35
