### PR TITLE
Implement review retry loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ shinobi review
 
 `watch` や merge などの後続コマンドは将来候補です。
 
-現在の実装では foundations に加えて、`shinobi run` / `shinobi run --issue <id>` の select / start / publish phase と、`shinobi review` の CI polling が動作します。Issue 選択、`.shinobi/run.lock` によるローカル排他、`feature/issue-<id>-<slug>` branch 作成、start 用の machine-readable comment 投稿、検証コマンド実行、branch push、draft PR 作成または更新、publish 用の label / mission-state comment 更新、review phase の CI 待機結果の state 保存まで実装済みです。context builder の run phase 統合、review loop の自動修正、auto-merge は未実装です。
+現在の実装では foundations に加えて、`shinobi run` / `shinobi run --issue <id>` の select / start / publish phase と、`shinobi review` の CI polling / retry 判定が動作します。Issue 選択、`.shinobi/run.lock` によるローカル排他、`feature/issue-<id>-<slug>` branch 作成、start 用の machine-readable comment 投稿、検証コマンド実行、branch push、draft PR 作成または更新、publish 用の label / mission-state comment 更新、review phase の CI 待機結果と retry state の保存まで実装済みです。context builder の run phase 統合、AI による review loop の自動修正、auto-merge は未実装です。
 
 ## ドキュメント構成
 
@@ -88,4 +88,4 @@ shinobi review
 
 ## 現在の状態
 
-このリポジトリは foundations 実装に加え、`run` の start / publish phase、`review` の CI polling、context builder を持ちます。現在は `.shinobi/` の初期化、ローカル state/config の保存、`status` のローカル表示と GitHub 照合、`run` の issue 選択、stale/live lock 判定、branch 作成、start 用 comment 投稿、GitHub label の start 遷移、検証コマンド実行、branch push、draft PR 作成または更新、publish 用 comment / label / state 更新、review 用の CI 状態取得と結果保存、Issue 由来の最小 context 構築までを持ちます。context phase の run 統合、review loop の自動修正、自動 merge はこれから実装します。
+このリポジトリは foundations 実装に加え、`run` の start / publish phase、`review` の CI polling / retry 判定、context builder を持ちます。現在は `.shinobi/` の初期化、ローカル state/config の保存、`status` のローカル表示と GitHub 照合、`run` の issue 選択、stale/live lock 判定、branch 作成、start 用 comment 投稿、GitHub label の start 遷移、検証コマンド実行、branch push、draft PR 作成または更新、publish 用 comment / label / state 更新、review 用の CI 状態取得、retry state 保存、上限到達時の `needs-human` finalize、Issue 由来の最小 context 構築までを持ちます。context phase の run 統合、AI による review loop の自動修正、自動 merge はこれから実装します。

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -25,7 +25,6 @@ from .mission_publish import (
     find_blocking_publish_labels,
     load_publishable_issue_label_names,
     publish_mission,
-    push_branch,
     stop_publish_for_blocking_labels,
     upsert_review_comment,
 )
@@ -517,6 +516,7 @@ def command_review(
                     root=root,
                     store=store,
                     config=config,
+                    client=client,
                     run_id=run_id,
                     state=state,
                     ci_status=ci_status,
@@ -601,6 +601,7 @@ def handle_failed_ci_review(
     root: Path,
     store: StateStore,
     config: Config,
+    client: GitHubClient,
     run_id: str,
     state: State,
     ci_status: Any,
@@ -682,10 +683,49 @@ def handle_failed_ci_review(
         print(reason)
         return 1
 
-    push_branch(root, branch)
+    retry_run_ids = failed_actions_run_ids(ci_status)
+    if not retry_run_ids:
+        stop_lease_expires_at = store.format_timestamp(
+            datetime.now(timezone.utc) + timedelta(minutes=config.mission_lease_minutes)
+        )
+        reason = (
+            "Shinobi stopped review retry because local verification passed after CI failure, "
+            "but no rerunnable GitHub Actions workflow run was found."
+        )
+        finalize_mission(
+            root=root,
+            store=store,
+            config=config,
+            run_id=run_id,
+            state=build_review_state(
+                state=state,
+                config=config,
+                run_id=run_id,
+                phase="review",
+                review_loop_count=state.review_loop_count,
+                lease_expires_at=stop_lease_expires_at,
+                last_result="ci-failure",
+                last_error=reason,
+                ci_status=ci_status,
+                execution_result=execution_result,
+            ),
+            conclusion="needs-human",
+            reason=reason,
+        )
+        print(f"review_issue: #{issue_number}")
+        print(f"review_pr: #{pr_number}")
+        print("ci_status: failure")
+        print("review_result: needs-human")
+        print(reason)
+        return 1
+
+    for retry_run_id in retry_run_ids:
+        client.rerun_workflow_run(retry_run_id)
+
     retry_count = state.review_loop_count + 1
     retry_reason = (
-        "CI failed; local verification passed and the branch was pushed for another review pass."
+        "CI failed; local verification passed and failed GitHub Actions workflow "
+        f"run(s) were rerun: {', '.join(retry_run_ids)}."
     )
     retry_now = datetime.now(timezone.utc)
     retry_lease_expires_at = store.format_timestamp(
@@ -709,6 +749,7 @@ def handle_failed_ci_review(
             last_error=retry_reason,
             ci_status=ci_status,
             execution_result=execution_result,
+            retry_run_ids=retry_run_ids,
         )
     )
 
@@ -719,6 +760,34 @@ def handle_failed_ci_review(
     print("review_result: retry")
     print("next_phase: review")
     return 1
+
+
+def failed_actions_run_ids(ci_status: Any) -> list[str]:
+    run_ids: list[str] = []
+    seen: set[str] = set()
+    for check in ci_status.checks:
+        if check.bucket not in {"fail", "cancel"} or not check.link:
+            continue
+        run_id = parse_actions_run_id(check.link)
+        if run_id is None or run_id in seen:
+            continue
+        seen.add(run_id)
+        run_ids.append(run_id)
+    return run_ids
+
+
+def parse_actions_run_id(link: str) -> str | None:
+    marker = "/actions/runs/"
+    marker_index = link.find(marker)
+    if marker_index == -1:
+        return None
+    suffix = link[marker_index + len(marker):]
+    run_id = ""
+    for character in suffix:
+        if not character.isdigit():
+            break
+        run_id += character
+    return run_id or None
 
 
 def require_review_issue_number(state: State) -> int:
@@ -751,6 +820,7 @@ def build_review_state(
     last_error: str | None,
     ci_status: Any,
     execution_result: ExecutionResult | None = None,
+    retry_run_ids: list[str] | None = None,
 ) -> State:
     extra: dict[str, Any] = {
         **state.extra,
@@ -758,6 +828,8 @@ def build_review_state(
     }
     if execution_result is not None:
         extra["retry_verification"] = serialize_execution_result(execution_result)
+    if retry_run_ids is not None:
+        extra["retry_workflow_run_ids"] = retry_run_ids
 
     return State(
         issue_number=state.issue_number,

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -50,6 +50,12 @@ class StatusMissionRef:
     conclusion: str | None = None
 
 
+@dataclass(frozen=True)
+class ActionsRunRetry:
+    run_id: str
+    failed_only: bool
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="shinobi")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -684,8 +690,8 @@ def handle_failed_ci_review(
         print(reason)
         return 1
 
-    retry_run_ids = failed_actions_run_ids(ci_status, repo=config.repo)
-    if not retry_run_ids:
+    retry_runs = actions_run_retries(ci_status, repo=config.repo)
+    if not retry_runs:
         stop_lease_expires_at = store.format_timestamp(
             datetime.now(timezone.utc) + timedelta(minutes=config.mission_lease_minutes)
         )
@@ -720,9 +726,10 @@ def handle_failed_ci_review(
         print(reason)
         return 1
 
-    for retry_run_id in retry_run_ids:
-        client.rerun_workflow_run(retry_run_id)
+    for retry_run in retry_runs:
+        client.rerun_workflow_run(retry_run.run_id, failed_only=retry_run.failed_only)
 
+    retry_run_ids = [retry_run.run_id for retry_run in retry_runs]
     retry_count = state.review_loop_count + 1
     retry_reason = (
         "CI failed; local verification passed and failed GitHub Actions workflow "
@@ -764,17 +771,22 @@ def handle_failed_ci_review(
 
 
 def failed_actions_run_ids(ci_status: Any, *, repo: str) -> list[str]:
-    run_ids: list[str] = []
-    seen: set[str] = set()
+    return [retry.run_id for retry in actions_run_retries(ci_status, repo=repo)]
+
+
+def actions_run_retries(ci_status: Any, *, repo: str) -> list[ActionsRunRetry]:
+    retries: dict[str, ActionsRunRetry] = {}
     for check in ci_status.checks:
         if check.bucket not in {"fail", "cancel"} or not check.link:
             continue
         run_id = parse_actions_run_id(check.link, repo=repo)
-        if run_id is None or run_id in seen:
+        if run_id is None:
             continue
-        seen.add(run_id)
-        run_ids.append(run_id)
-    return run_ids
+        failed_only = check.bucket != "cancel"
+        if run_id in retries:
+            failed_only = retries[run_id].failed_only and failed_only
+        retries[run_id] = ActionsRunRetry(run_id=run_id, failed_only=failed_only)
+    return list(retries.values())
 
 
 def parse_actions_run_id(link: str, *, repo: str) -> str | None:

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, List, Optional
+from urllib.parse import urlparse
 
 from .config import discover_workspace_root
 from .executor import detect_high_risk_stop, execute_verification
@@ -683,7 +684,7 @@ def handle_failed_ci_review(
         print(reason)
         return 1
 
-    retry_run_ids = failed_actions_run_ids(ci_status)
+    retry_run_ids = failed_actions_run_ids(ci_status, repo=config.repo)
     if not retry_run_ids:
         stop_lease_expires_at = store.format_timestamp(
             datetime.now(timezone.utc) + timedelta(minutes=config.mission_lease_minutes)
@@ -762,13 +763,13 @@ def handle_failed_ci_review(
     return 1
 
 
-def failed_actions_run_ids(ci_status: Any) -> list[str]:
+def failed_actions_run_ids(ci_status: Any, *, repo: str) -> list[str]:
     run_ids: list[str] = []
     seen: set[str] = set()
     for check in ci_status.checks:
         if check.bucket not in {"fail", "cancel"} or not check.link:
             continue
-        run_id = parse_actions_run_id(check.link)
+        run_id = parse_actions_run_id(check.link, repo=repo)
         if run_id is None or run_id in seen:
             continue
         seen.add(run_id)
@@ -776,12 +777,12 @@ def failed_actions_run_ids(ci_status: Any) -> list[str]:
     return run_ids
 
 
-def parse_actions_run_id(link: str) -> str | None:
-    marker = "/actions/runs/"
-    marker_index = link.find(marker)
-    if marker_index == -1:
+def parse_actions_run_id(link: str, *, repo: str) -> str | None:
+    marker = f"/{repo.strip('/')}/actions/runs/"
+    parsed = urlparse(link)
+    if not parsed.path.startswith(marker):
         return None
-    suffix = link[marker_index + len(marker):]
+    suffix = parsed.path[len(marker):]
     run_id = ""
     for character in suffix:
         if not character.isdigit():

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -6,7 +6,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, Callable, List, Optional
 
 from .config import discover_workspace_root
 from .executor import detect_high_risk_stop, execute_verification
@@ -18,12 +18,14 @@ from .issue_selector import (
     list_open_issues_with_any_label,
     select_ready_issue,
 )
+from .mission_finalize import MissionFinalizeError, finalize_mission
 from .mission_publish import (
     MissionPublishError,
     blocking_verification_results,
     find_blocking_publish_labels,
     load_publishable_issue_label_names,
     publish_mission,
+    push_branch,
     stop_publish_for_blocking_labels,
     upsert_review_comment,
 )
@@ -509,6 +511,33 @@ def command_review(
         completed_lease_expires_at = store.format_timestamp(
             completed_at + timedelta(minutes=config.mission_lease_minutes)
         )
+        if ci_status.is_failed:
+            try:
+                return handle_failed_ci_review(
+                    root=root,
+                    store=store,
+                    config=config,
+                    run_id=run_id,
+                    state=state,
+                    ci_status=ci_status,
+                    lease_expires_at=completed_lease_expires_at,
+                    update_review_comment=update_review_comment,
+                )
+            except (
+                MissionFinalizeError,
+                MissionPublishError,
+                ReviewerError,
+                RuntimeError,
+                ValueError,
+            ) as error:
+                persist_review_error(str(error))
+                print(f"review aborted: {error}")
+                return 1
+            except OSError as error:
+                persist_review_error(f"failed to persist CI review retry result: {error}")
+                print(f"review aborted: failed to persist CI review retry result: {error}")
+                return 1
+
         review_state = State(
             issue_number=state.issue_number,
             pr_number=state.pr_number,
@@ -565,6 +594,217 @@ def command_review(
         return 1 if ci_status.timed_out or ci_status.is_failed else 0
     finally:
         store.clear_lock(run_id)
+
+
+def handle_failed_ci_review(
+    *,
+    root: Path,
+    store: StateStore,
+    config: Config,
+    run_id: str,
+    state: State,
+    ci_status: Any,
+    lease_expires_at: str,
+    update_review_comment: Callable[..., None],
+) -> int:
+    issue_number = require_review_issue_number(state)
+    pr_number = require_review_pr_number(state)
+    branch = require_review_branch(state)
+
+    if state.review_loop_count >= config.max_review_loops:
+        reason = (
+            "Shinobi stopped review because CI failed and review loop count "
+            f"{state.review_loop_count} reached max_review_loops {config.max_review_loops}."
+        )
+        finalize_mission(
+            root=root,
+            store=store,
+            config=config,
+            run_id=run_id,
+            state=build_review_state(
+                state=state,
+                config=config,
+                run_id=run_id,
+                phase="review",
+                review_loop_count=state.review_loop_count,
+                lease_expires_at=lease_expires_at,
+                last_result="ci-failure",
+                last_error=reason,
+                ci_status=ci_status,
+            ),
+            conclusion="needs-human",
+            reason=reason,
+        )
+        print(f"review_issue: #{issue_number}")
+        print(f"review_pr: #{pr_number}")
+        print("ci_status: failure")
+        print("review_result: needs-human")
+        print(reason)
+        return 1
+
+    execution_result = execute_verification(root, config)
+    blocking_results = blocking_verification_results(execution_result)
+    if blocking_results:
+        stop_lease_expires_at = store.format_timestamp(
+            datetime.now(timezone.utc) + timedelta(minutes=config.mission_lease_minutes)
+        )
+        rendered_results = ", ".join(
+            f"{command.name}: {command.status}" for command in blocking_results
+        )
+        reason = (
+            "Shinobi stopped review retry because local verification failed "
+            f"after CI failure ({rendered_results})."
+        )
+        finalize_mission(
+            root=root,
+            store=store,
+            config=config,
+            run_id=run_id,
+            state=build_review_state(
+                state=state,
+                config=config,
+                run_id=run_id,
+                phase="review",
+                review_loop_count=state.review_loop_count,
+                lease_expires_at=stop_lease_expires_at,
+                last_result="ci-failure",
+                last_error=reason,
+                ci_status=ci_status,
+                execution_result=execution_result,
+            ),
+            conclusion="needs-human",
+            reason=reason,
+        )
+        print(f"review_issue: #{issue_number}")
+        print(f"review_pr: #{pr_number}")
+        print("ci_status: failure")
+        print("review_result: needs-human")
+        print(reason)
+        return 1
+
+    push_branch(root, branch)
+    retry_count = state.review_loop_count + 1
+    retry_reason = (
+        "CI failed; local verification passed and the branch was pushed for another review pass."
+    )
+    retry_now = datetime.now(timezone.utc)
+    retry_lease_expires_at = store.format_timestamp(
+        retry_now + timedelta(minutes=config.mission_lease_minutes)
+    )
+    store.refresh_lock_heartbeat(
+        run_id=run_id,
+        agent_identity=config.agent_identity,
+        now=retry_now,
+    )
+    update_review_comment(comment_lease_expires_at=retry_lease_expires_at)
+    store.save_state(
+        build_review_state(
+            state=state,
+            config=config,
+            run_id=run_id,
+            phase="review",
+            review_loop_count=retry_count,
+            lease_expires_at=retry_lease_expires_at,
+            last_result="review-retry",
+            last_error=retry_reason,
+            ci_status=ci_status,
+            execution_result=execution_result,
+        )
+    )
+
+    print(f"review_issue: #{issue_number}")
+    print(f"review_pr: #{pr_number}")
+    print("ci_status: failure")
+    print(f"review_loop_count: {retry_count}")
+    print("review_result: retry")
+    print("next_phase: review")
+    return 1
+
+
+def require_review_issue_number(state: State) -> int:
+    if state.issue_number is None:
+        raise ReviewerError("review retry requires issue_number")
+    return state.issue_number
+
+
+def require_review_pr_number(state: State) -> int:
+    if state.pr_number is None:
+        raise ReviewerError("review retry requires pr_number")
+    return state.pr_number
+
+
+def require_review_branch(state: State) -> str:
+    if not state.branch:
+        raise ReviewerError("review retry requires branch")
+    return state.branch
+
+
+def build_review_state(
+    *,
+    state: State,
+    config: Config,
+    run_id: str,
+    phase: str,
+    review_loop_count: int,
+    lease_expires_at: str,
+    last_result: str,
+    last_error: str | None,
+    ci_status: Any,
+    execution_result: ExecutionResult | None = None,
+) -> State:
+    extra: dict[str, Any] = {
+        **state.extra,
+        "ci_status": serialize_ci_status(ci_status),
+    }
+    if execution_result is not None:
+        extra["retry_verification"] = serialize_execution_result(execution_result)
+
+    return State(
+        issue_number=state.issue_number,
+        pr_number=state.pr_number,
+        branch=state.branch,
+        agent_identity=config.agent_identity,
+        run_id=run_id,
+        phase=phase,
+        review_loop_count=review_loop_count,
+        retryable_local_only=False,
+        lease_expires_at=lease_expires_at,
+        last_result=last_result,
+        last_error=last_error,
+        last_mission=state.last_mission,
+        extra=extra,
+    )
+
+
+def serialize_ci_status(ci_status: Any) -> dict[str, Any]:
+    return {
+        "status": ci_status.status,
+        "timed_out": ci_status.timed_out,
+        "checks": [
+            {
+                "name": check.name,
+                "state": check.state,
+                "bucket": check.bucket,
+                "link": check.link,
+            }
+            for check in ci_status.checks
+        ],
+    }
+
+
+def serialize_execution_result(execution_result: ExecutionResult) -> dict[str, Any]:
+    return {
+        "commands": [
+            {
+                "name": command.name,
+                "status": command.status,
+                "returncode": command.returncode,
+                "message": command.message,
+            }
+            for command in execution_result.commands
+        ],
+        "change_summary": execution_result.change_summary,
+    }
 
 
 def render_review_result(ci_status: Any) -> str:

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -779,6 +779,8 @@ def failed_actions_run_ids(ci_status: Any, *, repo: str) -> list[str]:
 
 def parse_actions_run_id(link: str, *, repo: str) -> str | None:
     parsed = urlparse(link)
+    if parsed.scheme != "https" or parsed.hostname != "github.com":
+        return None
     repo_parts = [part for part in repo.strip("/").split("/") if part]
     path_parts = [part for part in parsed.path.split("/") if part]
     expected_prefix = [*repo_parts, "actions", "runs"]

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -778,17 +778,16 @@ def failed_actions_run_ids(ci_status: Any, *, repo: str) -> list[str]:
 
 
 def parse_actions_run_id(link: str, *, repo: str) -> str | None:
-    marker = f"/{repo.strip('/')}/actions/runs/"
     parsed = urlparse(link)
-    if not parsed.path.startswith(marker):
+    repo_parts = [part for part in repo.strip("/").split("/") if part]
+    path_parts = [part for part in parsed.path.split("/") if part]
+    expected_prefix = [*repo_parts, "actions", "runs"]
+    if path_parts[: len(expected_prefix)] != expected_prefix:
         return None
-    suffix = parsed.path[len(marker):]
-    run_id = ""
-    for character in suffix:
-        if not character.isdigit():
-            break
-        run_id += character
-    return run_id or None
+    if len(path_parts) <= len(expected_prefix):
+        return None
+    run_id = path_parts[len(expected_prefix)]
+    return run_id if run_id.isdigit() else None
 
 
 def require_review_issue_number(state: State) -> int:

--- a/src/shinobi/github_client.py
+++ b/src/shinobi/github_client.py
@@ -243,7 +243,7 @@ class GitHubClient:
 
     def rerun_workflow_run(self, run_id: str) -> None:
         self._run_gh(
-            ["run", "rerun", run_id, "--failed"],
+            ["run", "rerun", run_id, "--failed", "--repo", self.repo],
             action=f"rerun failed jobs for workflow run {run_id}",
         )
 

--- a/src/shinobi/github_client.py
+++ b/src/shinobi/github_client.py
@@ -241,6 +241,12 @@ class GitHubClient:
             )
         return payload
 
+    def rerun_workflow_run(self, run_id: str) -> None:
+        self._run_gh(
+            ["run", "rerun", run_id, "--failed"],
+            action=f"rerun failed jobs for workflow run {run_id}",
+        )
+
     def merge_pull_request(
         self,
         pr_number: int,

--- a/src/shinobi/github_client.py
+++ b/src/shinobi/github_client.py
@@ -241,10 +241,15 @@ class GitHubClient:
             )
         return payload
 
-    def rerun_workflow_run(self, run_id: str) -> None:
+    def rerun_workflow_run(self, run_id: str, *, failed_only: bool = True) -> None:
+        args = ["run", "rerun", run_id]
+        if failed_only:
+            args.append("--failed")
+        args.extend(["--repo", self.repo])
+        rerun_target = "failed jobs for" if failed_only else "entire"
         self._run_gh(
-            ["run", "rerun", run_id, "--failed", "--repo", self.repo],
-            action=f"rerun failed jobs for workflow run {run_id}",
+            args,
+            action=f"rerun {rerun_target} workflow run {run_id}",
         )
 
     def merge_pull_request(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -829,7 +829,7 @@ class CliTest(unittest.TestCase):
             self.assertIn("review_result: retry", rendered)
             self.assertIn("next_phase: review", rendered)
             execute_verification_mock.assert_called_once()
-            client.rerun_workflow_run.assert_called_once_with("123456789")
+            client.rerun_workflow_run.assert_called_once_with("123456789", failed_only=True)
 
             saved_state = store.load_state()
             self.assertEqual(saved_state.phase, "review")
@@ -982,6 +982,41 @@ class CliTest(unittest.TestCase):
         self.assertEqual(
             cli.failed_actions_run_ids(status, repo="owner/repo"),
             ["123456789"],
+        )
+
+    def test_actions_run_retries_reruns_canceled_actions_runs_entirely(self) -> None:
+        status = CIStatus(
+            checks=[
+                PullRequestCheck(
+                    name="cancelled",
+                    state="CANCELLED",
+                    bucket="cancel",
+                    link="https://github.com/owner/repo/actions/runs/123456789",
+                ),
+                PullRequestCheck(
+                    name="failed",
+                    state="FAILURE",
+                    bucket="fail",
+                    link="https://github.com/owner/repo/actions/runs/123456789",
+                ),
+                PullRequestCheck(
+                    name="other-failed",
+                    state="FAILURE",
+                    bucket="fail",
+                    link="https://github.com/owner/repo/actions/runs/222",
+                ),
+            ],
+            status="failure",
+        )
+
+        retries = cli.actions_run_retries(status, repo="owner/repo")
+
+        self.assertEqual(
+            retries,
+            [
+                cli.ActionsRunRetry(run_id="123456789", failed_only=False),
+                cli.ActionsRunRetry(run_id="222", failed_only=True),
+            ],
         )
 
     def test_review_failed_ci_finalizes_needs_human_when_retry_verification_fails(self) -> None:
@@ -5967,6 +6002,24 @@ class GitHubClientTest(unittest.TestCase):
         self.assertEqual(
             run_mock.call_args.args[0],
             ["gh", "run", "rerun", "123456789", "--failed", "--repo", "owner/repo"],
+        )
+
+    def test_rerun_workflow_run_can_rerun_entire_run(self) -> None:
+        response = subprocess.CompletedProcess(
+            args=["gh", "run", "rerun", "123456789"],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        with patch("shinobi.github_client.discover_repo_slug", return_value="owner/repo"):
+            with patch("shinobi.github_client.subprocess.run", return_value=response) as run_mock:
+                client = GitHubClient(Path("/tmp/repo"))
+                client.rerun_workflow_run("123456789", failed_only=False)
+
+        self.assertEqual(
+            run_mock.call_args.args[0],
+            ["gh", "run", "rerun", "123456789", "--repo", "owner/repo"],
         )
 
     def test_list_issue_comments_reads_comments_from_issue_view(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -963,6 +963,12 @@ class CliTest(unittest.TestCase):
                     bucket="fail",
                     link="https://github.com/other/repo/actions/runs/444",
                 ),
+                PullRequestCheck(
+                    name="malformed-run-id",
+                    state="FAILURE",
+                    bucket="fail",
+                    link="https://github.com/owner/repo/actions/runs/555abc",
+                ),
             ],
             status="failure",
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -751,7 +751,7 @@ class CliTest(unittest.TestCase):
                 self.assertIn("pr: 44", call.args[1])
             self.assertIsNone(store.load_lock())
 
-    def test_review_failed_ci_returns_nonzero_and_persists_failure_result(self) -> None:
+    def test_review_failed_ci_retries_once_and_persists_retry_state(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)
             with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
@@ -789,6 +789,17 @@ class CliTest(unittest.TestCase):
                             ),
                         }
                     ]
+                    execution_result = ExecutionResult(
+                        commands=[
+                            VerificationCommandResult(
+                                name="test",
+                                command=["python3", "-m", "unittest"],
+                                status="passed",
+                                returncode=0,
+                            )
+                        ],
+                        change_summary="retry verification passed",
+                    )
                     with patch("shinobi.cli.GitHubClient", return_value=client):
                         with patch(
                             "shinobi.cli.wait_for_ci",
@@ -803,21 +814,112 @@ class CliTest(unittest.TestCase):
                                 status="failure",
                             ),
                         ):
-                            with redirect_stdout(output):
-                                exit_code = cli.main(["review"])
+                            with patch(
+                                "shinobi.cli.execute_verification",
+                                return_value=execution_result,
+                            ) as execute_verification_mock:
+                                with patch("shinobi.cli.push_branch") as push_branch_mock:
+                                    with redirect_stdout(output):
+                                        exit_code = cli.main(["review"])
 
             self.assertEqual(exit_code, 1)
             rendered = output.getvalue()
             self.assertIn("ci_status: failure", rendered)
-            self.assertIn("ci_timed_out: False", rendered)
+            self.assertIn("review_loop_count: 1", rendered)
+            self.assertIn("review_result: retry", rendered)
+            self.assertIn("next_phase: review", rendered)
+            execute_verification_mock.assert_called_once()
+            push_branch_mock.assert_called_once_with(root, "feature/issue-33-review-ci")
 
             saved_state = store.load_state()
             self.assertEqual(saved_state.phase, "review")
             self.assertEqual(saved_state.run_id, "publish-run")
-            self.assertEqual(saved_state.last_result, "ci-failure")
-            self.assertIsNone(saved_state.last_error)
+            self.assertEqual(saved_state.review_loop_count, 1)
+            self.assertEqual(saved_state.last_result, "review-retry")
+            self.assertEqual(
+                saved_state.last_error,
+                "CI failed; local verification passed and the branch was pushed for another review pass.",
+            )
             self.assertEqual(saved_state.extra["ci_status"]["status"], "failure")
             self.assertFalse(saved_state.extra["ci_status"]["timed_out"])
+            self.assertEqual(saved_state.extra["retry_verification"]["commands"][0]["status"], "passed")
+            self.assertIsNone(store.load_lock())
+
+    def test_review_failed_ci_finalizes_needs_human_when_loop_limit_reached(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            issue_number=33,
+                            pr_number=44,
+                            branch="feature/issue-33-review-ci",
+                            agent_identity=config.agent_identity,
+                            run_id="publish-run",
+                            phase="review",
+                            review_loop_count=3,
+                            last_result="review-retry",
+                        )
+                    )
+
+                    output = io.StringIO()
+                    client = Mock()
+                    client.list_issue_comments.return_value = [
+                        {
+                            "id": 9001,
+                            "body": (
+                                "<!-- shinobi:mission-state\n"
+                                "issue: 33\n"
+                                "branch: feature/issue-33-review-ci\n"
+                                "phase: review\n"
+                                "pr: 44\n"
+                                "-->\n"
+                            ),
+                        }
+                    ]
+                    client.get_issue.return_value = {
+                        "number": 33,
+                        "state": "OPEN",
+                        "labels": [{"name": config.labels["reviewing"]}],
+                    }
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
+                        with patch("shinobi.mission_finalize.GitHubClient", return_value=client):
+                            with patch(
+                                "shinobi.cli.wait_for_ci",
+                                return_value=CIStatus(
+                                    checks=[
+                                        PullRequestCheck(
+                                            name="test",
+                                            state="FAILURE",
+                                            bucket="fail",
+                                        )
+                                    ],
+                                    status="failure",
+                                ),
+                            ):
+                                with redirect_stdout(output):
+                                    exit_code = cli.main(["review"])
+
+            self.assertEqual(exit_code, 1)
+            rendered = output.getvalue()
+            self.assertIn("review_result: needs-human", rendered)
+            self.assertIn("max_review_loops 3", rendered)
+            client.update_issue_labels.assert_any_call(33, add=[config.labels["needs_human"]])
+            client.update_issue_labels.assert_any_call(33, remove=[config.labels["reviewing"]])
+            self.assertEqual(client.create_issue_comment.call_count, 1)
+
+            saved_state = store.load_state()
+            self.assertEqual(saved_state.phase, "idle")
+            self.assertEqual(saved_state.last_result, "needs-human")
+            self.assertEqual(saved_state.last_mission.issue_number, 33)
+            self.assertEqual(saved_state.last_mission.conclusion, "needs-human")
             self.assertIsNone(store.load_lock())
 
     def test_review_persists_last_error_when_ci_polling_aborts(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -958,6 +958,12 @@ class CliTest(unittest.TestCase):
                     link="https://ci.example.test/check/333",
                 ),
                 PullRequestCheck(
+                    name="same-path-external-host",
+                    state="FAILURE",
+                    bucket="fail",
+                    link="https://ci.example.test/owner/repo/actions/runs/333",
+                ),
+                PullRequestCheck(
                     name="other-repo",
                     state="FAILURE",
                     bucket="fail",
@@ -5944,6 +5950,24 @@ class GitHubClientTest(unittest.TestCase):
                 client.close_issue(6)
 
         self.assertEqual(run_mock.call_args.args[0][:4], ["gh", "issue", "close", "6"])
+
+    def test_rerun_workflow_run_scopes_command_to_repo(self) -> None:
+        response = subprocess.CompletedProcess(
+            args=["gh", "run", "rerun", "123456789"],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        with patch("shinobi.github_client.discover_repo_slug", return_value="owner/repo"):
+            with patch("shinobi.github_client.subprocess.run", return_value=response) as run_mock:
+                client = GitHubClient(Path("/tmp/repo"))
+                client.rerun_workflow_run("123456789")
+
+        self.assertEqual(
+            run_mock.call_args.args[0],
+            ["gh", "run", "rerun", "123456789", "--failed", "--repo", "owner/repo"],
+        )
 
     def test_list_issue_comments_reads_comments_from_issue_view(self) -> None:
         response = subprocess.CompletedProcess(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -809,6 +809,7 @@ class CliTest(unittest.TestCase):
                                         name="test",
                                         state="FAILURE",
                                         bucket="fail",
+                                        link="https://github.com/owner/repo/actions/runs/123456789/job/987",
                                     )
                                 ],
                                 status="failure",
@@ -818,9 +819,8 @@ class CliTest(unittest.TestCase):
                                 "shinobi.cli.execute_verification",
                                 return_value=execution_result,
                             ) as execute_verification_mock:
-                                with patch("shinobi.cli.push_branch") as push_branch_mock:
-                                    with redirect_stdout(output):
-                                        exit_code = cli.main(["review"])
+                                with redirect_stdout(output):
+                                    exit_code = cli.main(["review"])
 
             self.assertEqual(exit_code, 1)
             rendered = output.getvalue()
@@ -829,7 +829,7 @@ class CliTest(unittest.TestCase):
             self.assertIn("review_result: retry", rendered)
             self.assertIn("next_phase: review", rendered)
             execute_verification_mock.assert_called_once()
-            push_branch_mock.assert_called_once_with(root, "feature/issue-33-review-ci")
+            client.rerun_workflow_run.assert_called_once_with("123456789")
 
             saved_state = store.load_state()
             self.assertEqual(saved_state.phase, "review")
@@ -838,11 +838,13 @@ class CliTest(unittest.TestCase):
             self.assertEqual(saved_state.last_result, "review-retry")
             self.assertEqual(
                 saved_state.last_error,
-                "CI failed; local verification passed and the branch was pushed for another review pass.",
+                "CI failed; local verification passed and failed GitHub Actions workflow "
+                "run(s) were rerun: 123456789.",
             )
             self.assertEqual(saved_state.extra["ci_status"]["status"], "failure")
             self.assertFalse(saved_state.extra["ci_status"]["timed_out"])
             self.assertEqual(saved_state.extra["retry_verification"]["commands"][0]["status"], "passed")
+            self.assertEqual(saved_state.extra["retry_workflow_run_ids"], ["123456789"])
             self.assertIsNone(store.load_lock())
 
     def test_review_failed_ci_finalizes_needs_human_when_loop_limit_reached(self) -> None:
@@ -928,6 +930,39 @@ class CliTest(unittest.TestCase):
             self.assertEqual(saved_state.last_mission.conclusion, "needs-human")
             self.assertIsNone(store.load_lock())
 
+    def test_failed_actions_run_ids_extracts_unique_failed_action_runs(self) -> None:
+        status = CIStatus(
+            checks=[
+                PullRequestCheck(
+                    name="test",
+                    state="FAILURE",
+                    bucket="fail",
+                    link="https://github.com/owner/repo/actions/runs/123456789/job/987",
+                ),
+                PullRequestCheck(
+                    name="lint",
+                    state="FAILURE",
+                    bucket="fail",
+                    link="https://github.com/owner/repo/actions/runs/123456789",
+                ),
+                PullRequestCheck(
+                    name="docs",
+                    state="SUCCESS",
+                    bucket="pass",
+                    link="https://github.com/owner/repo/actions/runs/222",
+                ),
+                PullRequestCheck(
+                    name="external",
+                    state="FAILURE",
+                    bucket="fail",
+                    link="https://ci.example.test/check/333",
+                ),
+            ],
+            status="failure",
+        )
+
+        self.assertEqual(cli.failed_actions_run_ids(status), ["123456789"])
+
     def test_review_failed_ci_finalizes_needs_human_when_retry_verification_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)
@@ -1005,16 +1040,15 @@ class CliTest(unittest.TestCase):
                                     "shinobi.cli.execute_verification",
                                     return_value=execution_result,
                                 ) as execute_verification_mock:
-                                    with patch("shinobi.cli.push_branch") as push_branch_mock:
-                                        with redirect_stdout(output):
-                                            exit_code = cli.main(["review"])
+                                    with redirect_stdout(output):
+                                        exit_code = cli.main(["review"])
 
             self.assertEqual(exit_code, 1)
             rendered = output.getvalue()
             self.assertIn("review_result: needs-human", rendered)
             self.assertIn("local verification failed", rendered)
             execute_verification_mock.assert_called_once()
-            push_branch_mock.assert_not_called()
+            client.rerun_workflow_run.assert_not_called()
             client.update_issue_labels.assert_any_call(
                 33,
                 add=[config.labels["needs_human"]],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -957,11 +957,20 @@ class CliTest(unittest.TestCase):
                     bucket="fail",
                     link="https://ci.example.test/check/333",
                 ),
+                PullRequestCheck(
+                    name="other-repo",
+                    state="FAILURE",
+                    bucket="fail",
+                    link="https://github.com/other/repo/actions/runs/444",
+                ),
             ],
             status="failure",
         )
 
-        self.assertEqual(cli.failed_actions_run_ids(status), ["123456789"])
+        self.assertEqual(
+            cli.failed_actions_run_ids(status, repo="owner/repo"),
+            ["123456789"],
+        )
 
     def test_review_failed_ci_finalizes_needs_human_when_retry_verification_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -911,8 +911,118 @@ class CliTest(unittest.TestCase):
             rendered = output.getvalue()
             self.assertIn("review_result: needs-human", rendered)
             self.assertIn("max_review_loops 3", rendered)
-            client.update_issue_labels.assert_any_call(33, add=[config.labels["needs_human"]])
-            client.update_issue_labels.assert_any_call(33, remove=[config.labels["reviewing"]])
+            client.update_issue_labels.assert_any_call(
+                33,
+                add=[config.labels["needs_human"]],
+            )
+            client.update_issue_labels.assert_any_call(
+                33,
+                remove=[config.labels["reviewing"]],
+            )
+            self.assertEqual(client.create_issue_comment.call_count, 1)
+
+            saved_state = store.load_state()
+            self.assertEqual(saved_state.phase, "idle")
+            self.assertEqual(saved_state.last_result, "needs-human")
+            self.assertEqual(saved_state.last_mission.issue_number, 33)
+            self.assertEqual(saved_state.last_mission.conclusion, "needs-human")
+            self.assertIsNone(store.load_lock())
+
+    def test_review_failed_ci_finalizes_needs_human_when_retry_verification_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            issue_number=33,
+                            pr_number=44,
+                            branch="feature/issue-33-review-ci",
+                            agent_identity=config.agent_identity,
+                            run_id="publish-run",
+                            phase="review",
+                            review_loop_count=1,
+                            last_result="review-retry",
+                        )
+                    )
+
+                    output = io.StringIO()
+                    client = Mock()
+                    client.list_issue_comments.return_value = [
+                        {
+                            "id": 9001,
+                            "body": (
+                                "<!-- shinobi:mission-state\n"
+                                "issue: 33\n"
+                                "branch: feature/issue-33-review-ci\n"
+                                "phase: review\n"
+                                "pr: 44\n"
+                                "-->\n"
+                            ),
+                        }
+                    ]
+                    client.get_issue.return_value = {
+                        "number": 33,
+                        "state": "OPEN",
+                        "labels": [{"name": config.labels["reviewing"]}],
+                    }
+                    execution_result = ExecutionResult(
+                        commands=[
+                            VerificationCommandResult(
+                                name="test",
+                                command=["python3", "-m", "unittest"],
+                                status="failed",
+                                returncode=1,
+                            )
+                        ],
+                        change_summary="retry verification failed",
+                    )
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
+                        with patch(
+                            "shinobi.mission_finalize.GitHubClient",
+                            return_value=client,
+                        ):
+                            with patch(
+                                "shinobi.cli.wait_for_ci",
+                                return_value=CIStatus(
+                                    checks=[
+                                        PullRequestCheck(
+                                            name="test",
+                                            state="FAILURE",
+                                            bucket="fail",
+                                        )
+                                    ],
+                                    status="failure",
+                                ),
+                            ):
+                                with patch(
+                                    "shinobi.cli.execute_verification",
+                                    return_value=execution_result,
+                                ) as execute_verification_mock:
+                                    with patch("shinobi.cli.push_branch") as push_branch_mock:
+                                        with redirect_stdout(output):
+                                            exit_code = cli.main(["review"])
+
+            self.assertEqual(exit_code, 1)
+            rendered = output.getvalue()
+            self.assertIn("review_result: needs-human", rendered)
+            self.assertIn("local verification failed", rendered)
+            execute_verification_mock.assert_called_once()
+            push_branch_mock.assert_not_called()
+            client.update_issue_labels.assert_any_call(
+                33,
+                add=[config.labels["needs_human"]],
+            )
+            client.update_issue_labels.assert_any_call(
+                33,
+                remove=[config.labels["reviewing"]],
+            )
             self.assertEqual(client.create_issue_comment.call_count, 1)
 
             saved_state = store.load_state()


### PR DESCRIPTION
## Summary
- add bounded CI-failure retry handling to `shinobi review`
- run local verification before pushing a retry branch, update heartbeat/comment/state, and increment `review_loop_count`
- finalize to `needs-human` when retry budget is exhausted or local retry verification fails
- update README implementation status for review retry behavior

## Scope
- Addresses #36
- Does not implement stale recovery, merge, watch mode, or AI-authored automatic fixes

## Testing
- python3 -m unittest tests.test_cli
- env PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m compileall src tests
