### PR TITLE
Scope GitHub client commands to repo

### DIFF
--- a/src/shinobi/github_client.py
+++ b/src/shinobi/github_client.py
@@ -251,10 +251,9 @@ class GitHubClient:
         args = ["run", "rerun", run_id]
         if failed_only:
             args.append("--failed")
-        args.extend(["--repo", self.repo])
         rerun_target = "failed jobs for" if failed_only else "entire"
         self._run_gh(
-            args,
+            self._with_repo(args),
             action=f"rerun {rerun_target} workflow run {run_id}",
         )
 

--- a/src/shinobi/github_client.py
+++ b/src/shinobi/github_client.py
@@ -77,13 +77,13 @@ class GitHubClient:
 
     def create_issue_comment(self, issue_number: int, body: str) -> None:
         self._run_gh(
-            ["issue", "comment", str(issue_number), "--body", body],
+            self._with_repo(["issue", "comment", str(issue_number), "--body", body]),
             action=f"create comment on issue #{issue_number}",
         )
 
     def close_issue(self, issue_number: int) -> None:
         self._run_gh(
-            ["issue", "close", str(issue_number)],
+            self._with_repo(["issue", "close", str(issue_number)]),
             action=f"close issue #{issue_number}",
         )
 
@@ -142,7 +142,7 @@ class GitHubClient:
         ]
         if draft:
             args.append("--draft")
-        self._run_gh(args, action=f"create PR from {head} into {base}")
+        self._run_gh(self._with_repo(args), action=f"create PR from {head} into {base}")
         return self.get_pull_request(head)
 
     def update_pull_request(
@@ -160,26 +160,28 @@ class GitHubClient:
             args.extend(["--body", body])
         if base is not None:
             args.extend(["--base", base])
-        self._run_gh(args, action=f"update PR #{pr_number}")
+        self._run_gh(self._with_repo(args), action=f"update PR #{pr_number}")
         return self.get_pull_request(str(pr_number))
 
     def convert_pull_request_to_draft(self, pr_number: int) -> dict[str, Any]:
         self._run_gh(
-            ["pr", "ready", str(pr_number), "--undo"],
+            self._with_repo(["pr", "ready", str(pr_number), "--undo"]),
             action=f"convert PR #{pr_number} to draft",
         )
         return self.get_pull_request(str(pr_number))
 
     def convert_pull_request_to_ready(self, pr_number: int) -> dict[str, Any]:
         self._run_gh(
-            ["pr", "ready", str(pr_number)],
+            self._with_repo(["pr", "ready", str(pr_number)]),
             action=f"mark PR #{pr_number} ready for review",
         )
         return self.get_pull_request(str(pr_number))
 
     def get_pull_request(self, identifier: str) -> dict[str, Any]:
         payload = self._run_gh_json(
-            ["pr", "view", identifier, "--json", "number,url,isDraft,headRefName,baseRefName"],
+            self._with_repo(
+                ["pr", "view", identifier, "--json", "number,url,isDraft,headRefName,baseRefName"]
+            ),
             action=f"load PR {identifier}",
         )
         if not isinstance(payload, dict):
@@ -188,16 +190,18 @@ class GitHubClient:
 
     def list_pull_requests_by_head(self, head: str) -> list[dict[str, Any]]:
         payload = self._run_gh_json(
-            [
-                "pr",
-                "list",
-                "--head",
-                head,
-                "--state",
-                "open",
-                "--json",
-                "number,url,isDraft,headRefName,baseRefName",
-            ],
+            self._with_repo(
+                [
+                    "pr",
+                    "list",
+                    "--head",
+                    head,
+                    "--state",
+                    "open",
+                    "--json",
+                    "number,url,isDraft,headRefName,baseRefName",
+                ]
+            ),
             action=f"list PRs for head {head}",
         )
         if not isinstance(payload, list):
@@ -208,13 +212,15 @@ class GitHubClient:
 
     def get_ci_status(self, pr_number: int) -> list[dict[str, Any]]:
         result = self._run_gh(
-            [
-                "pr",
-                "checks",
-                str(pr_number),
-                "--json",
-                "name,state,link,bucket",
-            ],
+            self._with_repo(
+                [
+                    "pr",
+                    "checks",
+                    str(pr_number),
+                    "--json",
+                    "name,state,link,bucket",
+                ]
+            ),
             action=f"load CI status for PR #{pr_number}",
             allowed_returncodes={0, 1, 8},
         )
@@ -262,13 +268,16 @@ class GitHubClient:
         args = ["pr", "merge", str(pr_number), f"--{merge_method}"]
         if delete_branch:
             args.append("--delete-branch")
-        self._run_gh(args, action=f"merge PR #{pr_number}")
+        self._run_gh(self._with_repo(args), action=f"merge PR #{pr_number}")
 
     def _issue_edit(self, issue_number: int, args: list[str], action: str) -> None:
         self._run_gh(
-            ["issue", "edit", str(issue_number), *args],
+            self._with_repo(["issue", "edit", str(issue_number), *args]),
             action=f"{action} for issue #{issue_number}",
         )
+
+    def _with_repo(self, args: list[str]) -> list[str]:
+        return [*args, "--repo", self.repo]
 
     def _api_json(
         self,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5950,8 +5950,10 @@ class GitHubClientTest(unittest.TestCase):
         second_command = run_mock.call_args_list[1].args[0]
         self.assertIn("--add-label", first_command)
         self.assertIn("shinobi:working", first_command)
+        self.assertEqual(first_command[-2:], ["--repo", "owner/repo"])
         self.assertIn("--remove-label", second_command)
         self.assertIn("shinobi:ready", second_command)
+        self.assertEqual(second_command[-2:], ["--repo", "owner/repo"])
 
     def test_create_issue_comment_runs_gh_issue_comment(self) -> None:
         response = subprocess.CompletedProcess(
@@ -5970,6 +5972,7 @@ class GitHubClientTest(unittest.TestCase):
         self.assertEqual(command[:4], ["gh", "issue", "comment", "6"])
         self.assertIn("--body", command)
         self.assertIn("mission started", command)
+        self.assertEqual(command[-2:], ["--repo", "owner/repo"])
 
     def test_close_issue_runs_gh_issue_close(self) -> None:
         response = subprocess.CompletedProcess(
@@ -5984,7 +5987,9 @@ class GitHubClientTest(unittest.TestCase):
                 client = GitHubClient(Path("/tmp/repo"))
                 client.close_issue(6)
 
-        self.assertEqual(run_mock.call_args.args[0][:4], ["gh", "issue", "close", "6"])
+        command = run_mock.call_args.args[0]
+        self.assertEqual(command[:4], ["gh", "issue", "close", "6"])
+        self.assertEqual(command[-2:], ["--repo", "owner/repo"])
 
     def test_rerun_workflow_run_scopes_command_to_repo(self) -> None:
         response = subprocess.CompletedProcess(
@@ -6153,6 +6158,7 @@ class GitHubClientTest(unittest.TestCase):
         self.assertIn("--draft", create_command)
         self.assertIn("--head", create_command)
         self.assertIn("feature/issue-25", create_command)
+        self.assertEqual(create_command[-2:], ["--repo", "owner/repo"])
 
     def test_list_pull_requests_by_head_returns_open_prs_for_branch(self) -> None:
         response = subprocess.CompletedProcess(
@@ -6184,6 +6190,7 @@ class GitHubClientTest(unittest.TestCase):
         self.assertIn("feature/issue-25", command)
         self.assertIn("--state", command)
         self.assertIn("open", command)
+        self.assertEqual(command[-2:], ["--repo", "owner/repo"])
 
     def test_list_pull_requests_by_head_rejects_non_list_payload(self) -> None:
         response = subprocess.CompletedProcess(
@@ -6236,6 +6243,7 @@ class GitHubClientTest(unittest.TestCase):
         ready_command = run_mock.call_args_list[0].args[0]
         self.assertEqual(ready_command[:4], ["gh", "pr", "ready", "42"])
         self.assertIn("--undo", ready_command)
+        self.assertEqual(ready_command[-2:], ["--repo", "owner/repo"])
 
     def test_convert_pull_request_to_ready_fetches_updated_pr_metadata(self) -> None:
         responses = [
@@ -6271,6 +6279,7 @@ class GitHubClientTest(unittest.TestCase):
         ready_command = run_mock.call_args_list[0].args[0]
         self.assertEqual(ready_command[:4], ["gh", "pr", "ready", "42"])
         self.assertNotIn("--undo", ready_command)
+        self.assertEqual(ready_command[-2:], ["--repo", "owner/repo"])
 
     def test_init_keeps_shinobi_directory_ignored_by_git(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5869,7 +5869,7 @@ class GitHubClientTest(unittest.TestCase):
         )
 
         with patch("shinobi.github_client.discover_repo_slug", return_value="owner/repo"):
-            with patch("shinobi.github_client.subprocess.run", return_value=result):
+            with patch("shinobi.github_client.subprocess.run", return_value=result) as run_mock:
                 client = GitHubClient(Path("/tmp/repo"))
                 status = client.get_ci_status(44)
 
@@ -5884,6 +5884,9 @@ class GitHubClientTest(unittest.TestCase):
                 }
             ],
         )
+        command = run_mock.call_args.args[0]
+        self.assertEqual(command[:4], ["gh", "pr", "checks", "44"])
+        self.assertEqual(command[-2:], ["--repo", "owner/repo"])
 
     def test_get_ci_status_treats_no_checks_reported_as_empty_status(self) -> None:
         result = subprocess.CompletedProcess(
@@ -6160,6 +6163,67 @@ class GitHubClientTest(unittest.TestCase):
         self.assertIn("feature/issue-25", create_command)
         self.assertEqual(create_command[-2:], ["--repo", "owner/repo"])
 
+    def test_get_pull_request_scopes_view_command_to_repo(self) -> None:
+        response = subprocess.CompletedProcess(
+            args=["gh", "pr", "view", "42"],
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "number": 42,
+                    "url": "https://github.com/owner/repo/pull/42",
+                    "isDraft": False,
+                    "headRefName": "feature/issue-25",
+                    "baseRefName": "main",
+                }
+            ),
+            stderr="",
+        )
+
+        with patch("shinobi.github_client.discover_repo_slug", return_value="owner/repo"):
+            with patch("shinobi.github_client.subprocess.run", return_value=response) as run_mock:
+                client = GitHubClient(Path("/tmp/repo"))
+                pr = client.get_pull_request("42")
+
+        self.assertEqual(pr["number"], 42)
+        command = run_mock.call_args.args[0]
+        self.assertEqual(command[:4], ["gh", "pr", "view", "42"])
+        self.assertEqual(command[-2:], ["--repo", "owner/repo"])
+
+    def test_update_pull_request_scopes_edit_command_to_repo(self) -> None:
+        responses = [
+            subprocess.CompletedProcess(args=["gh", "pr", "edit", "42"], returncode=0, stdout="", stderr=""),
+            subprocess.CompletedProcess(
+                args=["gh", "pr", "view", "42"],
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "number": 42,
+                        "url": "https://github.com/owner/repo/pull/42",
+                        "isDraft": False,
+                        "headRefName": "feature/issue-25",
+                        "baseRefName": "main",
+                    }
+                ),
+                stderr="",
+            ),
+        ]
+
+        with patch("shinobi.github_client.discover_repo_slug", return_value="owner/repo"):
+            with patch("shinobi.github_client.subprocess.run", side_effect=responses) as run_mock:
+                client = GitHubClient(Path("/tmp/repo"))
+                pr = client.update_pull_request(42, title="updated title", body="updated body", base="develop")
+
+        self.assertEqual(pr["number"], 42)
+        command = run_mock.call_args_list[0].args[0]
+        self.assertEqual(command[:4], ["gh", "pr", "edit", "42"])
+        self.assertIn("--title", command)
+        self.assertIn("updated title", command)
+        self.assertIn("--body", command)
+        self.assertIn("updated body", command)
+        self.assertIn("--base", command)
+        self.assertIn("develop", command)
+        self.assertEqual(command[-2:], ["--repo", "owner/repo"])
+
     def test_list_pull_requests_by_head_returns_open_prs_for_branch(self) -> None:
         response = subprocess.CompletedProcess(
             args=["gh", "pr", "list"],
@@ -6280,6 +6344,25 @@ class GitHubClientTest(unittest.TestCase):
         self.assertEqual(ready_command[:4], ["gh", "pr", "ready", "42"])
         self.assertNotIn("--undo", ready_command)
         self.assertEqual(ready_command[-2:], ["--repo", "owner/repo"])
+
+    def test_merge_pull_request_scopes_merge_command_to_repo(self) -> None:
+        response = subprocess.CompletedProcess(
+            args=["gh", "pr", "merge", "42"],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        with patch("shinobi.github_client.discover_repo_slug", return_value="owner/repo"):
+            with patch("shinobi.github_client.subprocess.run", return_value=response) as run_mock:
+                client = GitHubClient(Path("/tmp/repo"))
+                client.merge_pull_request(42, merge_method="squash", delete_branch=True)
+
+        command = run_mock.call_args.args[0]
+        self.assertEqual(command[:4], ["gh", "pr", "merge", "42"])
+        self.assertIn("--squash", command)
+        self.assertIn("--delete-branch", command)
+        self.assertEqual(command[-2:], ["--repo", "owner/repo"])
 
     def test_init_keeps_shinobi_directory_ignored_by_git(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary
- append `--repo` to issue and PR scoped `gh` commands through a shared helper in `GitHubClient`
- keep repo targeting explicit for label, comment, PR, merge, and CI check operations
- extend GitHub client tests to lock the repo-scoped command shape

## Testing
- env PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m compileall src tests
- python3 -m unittest tests.test_cli.GitHubClientTest
- python3 -m unittest tests.test_cli

Closes #25
