### PR TITLE
Recover retryable local-only missions

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -241,7 +241,7 @@ shinobi watch
 
 PR 前セルフレビューでは `.shinobi/templates/self-review.md` を使います。review で新しい指摘を受けた場合は、必要に応じて `.shinobi/templates/review-note-rule.md` に沿って `.shinobi/review-notes.md` へ再発防止ルールを追記します。
 
-`--issue <id>` を指定した場合は、その Issue を最優先で扱います。resume を許可するのは、その Issue 自身の stale mission で、machine-readable metadata と local state から ownership と phase を復元できる場合に限ります。lease が有効な live mission には別プロセスから attach しません。`.shinobi/run.lock` の owner でない run は live mission の継続に参加せず停止します。別 Issue の active mission や、Shinobi 自身が retryable と記録した local-only mission が残っている場合も横取りせず停止します。
+`--issue <id>` を指定した場合は、その Issue を最優先で扱います。resume を許可するのは、その Issue 自身の stale mission、または branch 実体と retryable 記録で裏付けられたその Issue 自身の local-only mission に限ります。lease が有効な live mission には別プロセスから attach しません。`.shinobi/run.lock` の owner でない run は live mission の継続に参加せず停止します。別 Issue の active mission や、別 Issue に属する retryable local-only mission が残っている場合は横取りせず停止します。
 
 実装順序としては、run 開始時にまず `.shinobi/run.lock` を確認します。他 owner の stale でない lock が見つかった場合は、その workspace で live run が進行中とみなして停止します。stale lock を見つけた場合は、run は select phase 内でその lock を明示的に takeover してから recovery / cleanup を行えます。lock が存在しない場合は、その run 自身が select phase で live run 用の lock を取得してから stale mission の recovery / cleanup を進めます。`start` では、同じ lock ownership を維持したまま branch 作成と state 更新へ進みます。
 

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import subprocess
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -33,9 +34,10 @@ from .mission_start import (
     MissionStartError,
     StartedMission,
     handoff_started_mission,
+    resume_local_only_mission,
     start_mission,
 )
-from .models import Config, ExecutionResult, State, StopDecision
+from .models import Config, ExecutionResult, MissionSummary, State, StopDecision
 from .reviewer import ReviewerError, wait_for_ci
 from .state_store import StateStore
 
@@ -935,10 +937,23 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
             print(f"run aborted: failed to load local state: {state_error}")
             return 1
 
-        conflict = detect_local_mission_conflict(state=state, requested_issue=issue_number)
-        if conflict is not None:
-            print(f"run aborted: {conflict}")
+        local_only_issue, local_only_error = recover_local_only_mission_candidate(
+            root=root,
+            store=store,
+            config=config,
+            state=state,
+            requested_issue=issue_number,
+        )
+        if local_only_error is not None:
+            print(f"run aborted: {local_only_error}")
             return 1
+
+        state = store.load_state()
+        if local_only_issue is None:
+            conflict = detect_local_mission_conflict(state=state, requested_issue=issue_number)
+            if conflict is not None:
+                print(f"run aborted: {conflict}")
+                return 1
 
         try:
             active_issue_numbers = list_open_issues_with_any_label(
@@ -953,7 +968,7 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
             print(f"run aborted: {error}")
             return 1
 
-        selected_issue = issue_number
+        selected_issue = local_only_issue if local_only_issue is not None else issue_number
         if selected_issue is None:
             if active_issue_numbers:
                 rendered = ", ".join(f"#{number}" for number in active_issue_numbers)
@@ -994,14 +1009,25 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
 
         try:
             issue = load_issue(root, selected_issue, repo=config.repo)
-            started_mission = start_mission(
-                root=root,
-                store=store,
-                config=config,
-                run_id=run_id,
-                issue=issue,
-                now=now,
-            )
+            if local_only_issue is not None:
+                started_mission = resume_local_only_mission(
+                    root=root,
+                    store=store,
+                    config=config,
+                    run_id=run_id,
+                    issue=issue,
+                    state=store.load_state(),
+                    now=now,
+                )
+            else:
+                started_mission = start_mission(
+                    root=root,
+                    store=store,
+                    config=config,
+                    run_id=run_id,
+                    issue=issue,
+                    now=now,
+                )
             execution_result = execute_verification(root, config)
             handoff_failed_verification(
                 root=root,
@@ -1079,6 +1105,126 @@ def detect_local_mission_conflict(*, state: State, requested_issue: Optional[int
         )
 
     return None
+
+
+def recover_local_only_mission_candidate(
+    *,
+    root: Path,
+    store: StateStore,
+    config: Config,
+    state: State,
+    requested_issue: Optional[int],
+) -> tuple[int | None, str | None]:
+    if not state.retryable_local_only:
+        return None, None
+
+    issue_number = state.issue_number
+    if issue_number is None:
+        clear_retryable_local_only_state(
+            store=store,
+            state=state,
+            conclusion="aborted",
+            error="retryable local-only mission is missing issue_number",
+        )
+        return None, "retryable local-only mission exists but local state is missing issue_number"
+
+    if requested_issue is not None and requested_issue != issue_number:
+        return None, f"retryable local-only mission exists for issue #{issue_number}"
+
+    recovery_error = validate_retryable_local_only_state(
+        root=root,
+        store=store,
+        config=config,
+        state=state,
+    )
+    if recovery_error is not None:
+        clear_retryable_local_only_state(
+            store=store,
+            state=state,
+            conclusion="aborted",
+            error=recovery_error,
+        )
+        return None, (
+            f"retryable local-only mission for issue #{issue_number} could not be resumed: "
+            f"{recovery_error}"
+        )
+
+    return issue_number, None
+
+
+def validate_retryable_local_only_state(
+    *,
+    root: Path,
+    store: StateStore,
+    config: Config,
+    state: State,
+) -> str | None:
+    if state.phase != "start":
+        return f"phase must be start, got {state.phase}"
+    if not state.branch:
+        return "branch is missing"
+    if not state.run_id:
+        return "run_id is missing"
+    if not state.agent_identity:
+        return "agent_identity is missing"
+    if state.agent_identity != config.agent_identity:
+        return (
+            "agent_identity does not match current workspace "
+            f"({state.agent_identity} != {config.agent_identity})"
+        )
+    if not git_local_branch_exists(root, state.branch):
+        return f"branch {state.branch} does not exist locally"
+    if not store.has_retryable_start_failure(
+        issue_number=state.issue_number,
+        branch=state.branch,
+        phase=state.phase,
+        agent_identity=state.agent_identity,
+        run_id=state.run_id,
+    ):
+        return "retryable start failure record is missing"
+    return None
+
+
+def clear_retryable_local_only_state(
+    *,
+    store: StateStore,
+    state: State,
+    conclusion: str,
+    error: str,
+) -> None:
+    store.save_state(
+        State(
+            issue_number=None,
+            pr_number=None,
+            branch=None,
+            agent_identity=state.agent_identity,
+            run_id=None,
+            phase="idle",
+            review_loop_count=0,
+            retryable_local_only=False,
+            lease_expires_at=None,
+            last_result=conclusion,
+            last_error=error,
+            last_mission=MissionSummary(
+                issue_number=state.issue_number,
+                pr_number=state.pr_number,
+                branch=state.branch,
+                phase=state.phase,
+                conclusion=conclusion,
+            ),
+        )
+    )
+
+
+def git_local_branch_exists(root: Path, branch: str) -> bool:
+    result = subprocess.run(
+        ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
 
 
 def handoff_failed_verification(

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -969,9 +969,14 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
             return 1
 
         selected_issue = local_only_issue if local_only_issue is not None else issue_number
+        blocking_active_issue_numbers = active_issue_numbers
+        if local_only_issue is not None:
+            blocking_active_issue_numbers = [
+                number for number in active_issue_numbers if number != local_only_issue
+            ]
         if selected_issue is None:
-            if active_issue_numbers:
-                rendered = ", ".join(f"#{number}" for number in active_issue_numbers)
+            if blocking_active_issue_numbers:
+                rendered = ", ".join(f"#{number}" for number in blocking_active_issue_numbers)
                 print(
                     "run aborted: active GitHub mission exists for "
                     f"{rendered}; recovery/resume is not implemented yet"
@@ -986,8 +991,8 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
                 print(f"run aborted: no open issues labeled {config.labels['ready']}")
                 return 1
         else:
-            if active_issue_numbers:
-                rendered = ", ".join(f"#{number}" for number in active_issue_numbers)
+            if blocking_active_issue_numbers:
+                rendered = ", ".join(f"#{number}" for number in blocking_active_issue_numbers)
                 print(
                     "run aborted: active GitHub mission exists for "
                     f"{rendered}; targeted resume/cancel is not implemented yet"
@@ -1001,6 +1006,7 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
                         config.labels["working"],
                         config.labels["reviewing"],
                     ),
+                    allow_active_labels=local_only_issue is not None,
                     repo=config.repo,
                 )
             except RuntimeError as error:

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -1134,9 +1134,6 @@ def recover_local_only_mission_candidate(
         )
         return None, "retryable local-only mission exists but local state is missing issue_number"
 
-    if requested_issue is not None and requested_issue != issue_number:
-        return None, f"retryable local-only mission exists for issue #{issue_number}"
-
     recovery_error = validate_retryable_local_only_state(
         root=root,
         store=store,
@@ -1154,6 +1151,9 @@ def recover_local_only_mission_candidate(
             f"retryable local-only mission for issue #{issue_number} could not be resumed: "
             f"{recovery_error}"
         )
+
+    if requested_issue is not None and requested_issue != issue_number:
+        return None, f"retryable local-only mission exists for issue #{issue_number}"
 
     return issue_number, None
 

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -1126,13 +1126,18 @@ def recover_local_only_mission_candidate(
 
     issue_number = state.issue_number
     if issue_number is None:
-        clear_retryable_local_only_state(
+        cleanup_error = cleanup_retryable_local_only_state(
+            root=root,
             store=store,
+            config=config,
             state=state,
             conclusion="aborted",
             error="retryable local-only mission is missing issue_number",
         )
-        return None, "retryable local-only mission exists but local state is missing issue_number"
+        message = "retryable local-only mission exists but local state is missing issue_number"
+        if cleanup_error is not None:
+            message += f"; cleanup also failed: {cleanup_error}"
+        return None, message
 
     recovery_error = validate_retryable_local_only_state(
         root=root,
@@ -1141,16 +1146,21 @@ def recover_local_only_mission_candidate(
         state=state,
     )
     if recovery_error is not None:
-        clear_retryable_local_only_state(
+        cleanup_error = cleanup_retryable_local_only_state(
+            root=root,
             store=store,
+            config=config,
             state=state,
             conclusion="aborted",
             error=recovery_error,
         )
-        return None, (
+        message = (
             f"retryable local-only mission for issue #{issue_number} could not be resumed: "
             f"{recovery_error}"
         )
+        if cleanup_error is not None:
+            message += f"; cleanup also failed: {cleanup_error}"
+        return None, message
 
     if requested_issue is not None and requested_issue != issue_number:
         return None, f"retryable local-only mission exists for issue #{issue_number}"
@@ -1198,34 +1208,76 @@ def validate_retryable_local_only_state(
     return None
 
 
-def clear_retryable_local_only_state(
+def cleanup_retryable_local_only_state(
     *,
+    root: Path,
     store: StateStore,
+    config: Config,
     state: State,
     conclusion: str,
     error: str,
-) -> None:
-    store.save_state(
-        State(
-            issue_number=None,
-            pr_number=None,
-            branch=None,
-            agent_identity=state.agent_identity,
-            run_id=None,
-            phase="idle",
-            review_loop_count=0,
-            retryable_local_only=False,
-            lease_expires_at=None,
-            last_result=conclusion,
-            last_error=error,
-            last_mission=MissionSummary(
+) -> str | None:
+    try:
+        store.save_state(
+            State(
+                issue_number=None,
+                pr_number=None,
+                branch=None,
+                agent_identity=state.agent_identity,
+                run_id=None,
+                phase="idle",
+                review_loop_count=0,
+                retryable_local_only=False,
+                lease_expires_at=None,
+                last_result=conclusion,
+                last_error=error,
+                last_mission=MissionSummary(
+                    issue_number=state.issue_number,
+                    pr_number=state.pr_number,
+                    branch=state.branch,
+                    phase=state.phase,
+                    conclusion=conclusion,
+                ),
+            )
+        )
+    except OSError as save_error:
+        return f"failed to clear retryable local-only state: {save_error}"
+
+    if state.issue_number is None:
+        return None
+
+    try:
+        GitHubClient(root, repo=config.repo).create_issue_comment(
+            state.issue_number,
+            render_retryable_local_only_cleanup_comment(
                 issue_number=state.issue_number,
-                pr_number=state.pr_number,
                 branch=state.branch,
                 phase=state.phase,
-                conclusion=conclusion,
+                error=error,
             ),
         )
+    except GitHubClientError as comment_error:
+        return (
+            "failed to comment on cleared retryable local-only mission for "
+            f"issue #{state.issue_number}: {comment_error}"
+        )
+    return None
+
+
+def render_retryable_local_only_cleanup_comment(
+    *,
+    issue_number: int,
+    branch: str | None,
+    phase: str,
+    error: str,
+) -> str:
+    branch_line = branch if branch is not None else "unknown"
+    return (
+        "Shinobi cleared an invalid retryable local-only mission record and will not auto-resume it.\n\n"
+        f"- issue: #{issue_number}\n"
+        f"- branch: {branch_line}\n"
+        f"- phase: {phase}\n"
+        f"- reason: {error}\n"
     )
 
 

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -1180,6 +1180,13 @@ def validate_retryable_local_only_state(
         )
     if not git_local_branch_exists(root, state.branch):
         return f"branch {state.branch} does not exist locally"
+    current_branch = git_current_branch(root)
+    if current_branch != state.branch:
+        current_branch_label = current_branch if current_branch is not None else "detached HEAD"
+        return (
+            "current branch does not match retryable local-only branch "
+            f"({current_branch_label} != {state.branch})"
+        )
     if not store.has_retryable_start_failure(
         issue_number=state.issue_number,
         branch=state.branch,
@@ -1231,6 +1238,20 @@ def git_local_branch_exists(root: Path, branch: str) -> bool:
         text=True,
     )
     return result.returncode == 0
+
+
+def git_current_branch(root: Path) -> str | None:
+    result = subprocess.run(
+        ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    branch = result.stdout.strip()
+    return branch or None
 
 
 def handoff_failed_verification(

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -1217,13 +1217,15 @@ def cleanup_retryable_local_only_state(
     conclusion: str,
     error: str,
 ) -> str | None:
+    current_workspace_identity = config.agent_identity
+    state_belongs_to_current_workspace = state.agent_identity == current_workspace_identity
     try:
         store.save_state(
             State(
                 issue_number=None,
                 pr_number=None,
                 branch=None,
-                agent_identity=state.agent_identity,
+                agent_identity=current_workspace_identity,
                 run_id=None,
                 phase="idle",
                 review_loop_count=0,
@@ -1244,6 +1246,9 @@ def cleanup_retryable_local_only_state(
         return f"failed to clear retryable local-only state: {save_error}"
 
     if state.issue_number is None:
+        return None
+
+    if not state_belongs_to_current_workspace:
         return None
 
     try:

--- a/src/shinobi/mission_start.py
+++ b/src/shinobi/mission_start.py
@@ -199,6 +199,112 @@ def handoff_started_mission(
     )
 
 
+def resume_local_only_mission(
+    *,
+    root: Path,
+    store: StateStore,
+    config: Config,
+    run_id: str,
+    issue: dict,
+    state: State,
+    now: datetime | None = None,
+) -> StartedMission:
+    started_at = now or datetime.now(timezone.utc)
+    issue_number = require_startable_issue(issue, config)
+    if state.issue_number != issue_number:
+        raise MissionStartError(
+            "retryable local-only state issue does not match requested issue "
+            f"(state: {state.issue_number}, issue: {issue_number})"
+        )
+    if not state.branch:
+        raise MissionStartError(
+            f"retryable local-only mission for issue #{issue_number} is missing branch"
+        )
+
+    store.require_lock_owner(run_id, config.agent_identity)
+    lease_expires_at = store.format_timestamp(
+        started_at + timedelta(minutes=config.mission_lease_minutes)
+    )
+    issue_label_names = get_issue_label_names(issue)
+
+    try:
+        sync_start_labels(root, issue_number, config, issue_label_names=issue_label_names)
+    except MissionStartError as error:
+        state.last_error = str(error)
+        save_retryable_state_or_raise(
+            store=store,
+            state=state,
+            base_message=str(error),
+        )
+        raise error
+
+    try:
+        post_start_comment(
+            root=root,
+            issue_number=issue_number,
+            branch=state.branch,
+            lease_expires_at=lease_expires_at,
+            config=config,
+            run_id=run_id,
+        )
+    except MissionStartError as error:
+        state.last_error = str(error)
+        save_retryable_state_or_raise(
+            store=store,
+            state=state,
+            base_message=str(error),
+        )
+        raise error
+
+    active_state = State(
+        issue_number=issue_number,
+        pr_number=None,
+        branch=state.branch,
+        agent_identity=config.agent_identity,
+        run_id=run_id,
+        phase="start",
+        review_loop_count=0,
+        retryable_local_only=False,
+        lease_expires_at=lease_expires_at,
+        last_result="started",
+        last_error=None,
+    )
+    try:
+        store.save_state(active_state)
+    except OSError as error:
+        rollback_error = transition_issue_to_needs_human(
+            root=root,
+            issue_number=issue_number,
+            config=config,
+            reason=(
+                "Shinobi failed to persist final local state while resuming a local-only "
+                f"mission after updating active labels: {error}"
+            ),
+            known_label_names={config.labels["working"]},
+        )
+        state.last_error = (
+            "GitHub labels were updated but final local state persistence failed while "
+            f"resuming local-only mission: {error}"
+        )
+        if rollback_error is not None:
+            state.last_error += f"; rollback also failed: {rollback_error}"
+        failure_message = format_final_state_persistence_failure(
+            issue_number, error, rollback_error
+        )
+        save_retryable_state_or_raise(
+            store=store,
+            state=state,
+            base_message=failure_message,
+        )
+        raise MissionStartError(failure_message) from error
+
+    return StartedMission(
+        issue_number=issue_number,
+        branch=state.branch,
+        lease_expires_at=lease_expires_at,
+    )
+
+
 def build_branch_name(*, issue_number: int, issue_title: str) -> str:
     slug = slugify_issue_title(issue_title)
     return f"feature/issue-{issue_number}-{slug}"

--- a/src/shinobi/mission_start.py
+++ b/src/shinobi/mission_start.py
@@ -210,7 +210,7 @@ def resume_local_only_mission(
     now: datetime | None = None,
 ) -> StartedMission:
     started_at = now or datetime.now(timezone.utc)
-    issue_number = require_startable_issue(issue, config)
+    issue_number = require_resumable_local_only_issue(issue, config)
     if state.issue_number != issue_number:
         raise MissionStartError(
             "retryable local-only state issue does not match requested issue "
@@ -311,6 +311,30 @@ def build_branch_name(*, issue_number: int, issue_title: str) -> str:
 
 
 def require_startable_issue(issue: dict, config: Config) -> int:
+    return require_issue_with_allowed_status_labels(
+        issue,
+        config,
+        allowed_status_labels={config.labels["ready"]},
+        error_context="start",
+    )
+
+
+def require_resumable_local_only_issue(issue: dict, config: Config) -> int:
+    return require_issue_with_allowed_status_labels(
+        issue,
+        config,
+        allowed_status_labels={config.labels["ready"], config.labels["working"]},
+        error_context="resume local-only mission",
+    )
+
+
+def require_issue_with_allowed_status_labels(
+    issue: dict,
+    config: Config,
+    *,
+    allowed_status_labels: set[str],
+    error_context: str,
+) -> int:
     issue_number = int(issue["number"])
     if "pull_request" in issue:
         raise MissionStartError(f"issue #{issue_number} is a pull request, not an issue")
@@ -323,9 +347,15 @@ def require_startable_issue(issue: dict, config: Config) -> int:
         for label in issue.get("labels", [])
         if isinstance(label, dict)
     }
-    ready_label = config.labels["ready"]
-    if ready_label not in label_names:
-        raise MissionStartError(f"issue #{issue_number} is not labeled {ready_label}")
+    if not any(label in label_names for label in allowed_status_labels):
+        if len(allowed_status_labels) == 1:
+            expected_label = next(iter(allowed_status_labels))
+            raise MissionStartError(f"issue #{issue_number} is not labeled {expected_label}")
+        allowed = ", ".join(sorted(allowed_status_labels))
+        raise MissionStartError(
+            f"issue #{issue_number} is not in a {error_context} state; "
+            f"expected one of: {allowed}"
+        )
 
     blocked_label = config.labels["blocked"]
     needs_human_label = config.labels["needs_human"]

--- a/src/shinobi/state_store.py
+++ b/src/shinobi/state_store.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Tuple
+from typing import Any, Tuple
 
 try:
     import fcntl
@@ -283,6 +283,42 @@ class StateStore:
 
     def has_state(self) -> bool:
         return self.paths.config_path.exists() or self.paths.state_path.exists()
+
+    def has_retryable_start_failure(
+        self,
+        *,
+        issue_number: int,
+        branch: str,
+        phase: str,
+        agent_identity: str,
+        run_id: str,
+    ) -> bool:
+        return any(
+            entry.get("retryable_local_only") is True
+            and entry.get("issue_number") == issue_number
+            and entry.get("branch") == branch
+            and entry.get("phase") == phase
+            and entry.get("agent_identity") == agent_identity
+            and entry.get("run_id") == run_id
+            for entry in self.load_retryable_start_failures()
+        )
+
+    def load_retryable_start_failures(self) -> list[dict[str, Any]]:
+        log_path = self.paths.logs_dir / "retryable-start-failures.jsonl"
+        if not log_path.exists():
+            return []
+
+        entries: list[dict[str, Any]] = []
+        for line in log_path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                payload = json.loads(line)
+            except JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                entries.append(payload)
+        return entries
 
     def try_load_lock(self) -> Tuple[RunLock | None, str | None]:
         try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3556,6 +3556,75 @@ class MissionStartTest(unittest.TestCase):
             self.assertEqual(saved_state.last_result, "started")
             self.assertIsNone(saved_state.last_error)
 
+    def test_resume_local_only_mission_accepts_working_issue_label(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            store = StateStore(root)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                config, _ = store.initialize()
+
+            run_id = "run-456"
+            now = datetime(2026, 4, 11, 0, 0, tzinfo=timezone.utc)
+            store.save_lock(store.acquire_lock(config=config, run_id=run_id, pid=123, now=now)[0])
+            retryable_state = State(
+                issue_number=40,
+                pr_number=None,
+                branch="feature/issue-40-recover-local-only-mission",
+                agent_identity=config.agent_identity,
+                run_id="run-123",
+                phase="start",
+                review_loop_count=0,
+                retryable_local_only=True,
+                lease_expires_at=None,
+                last_result="start_pending",
+                last_error="persist failed once",
+            )
+            store.save_state(retryable_state)
+            (store.paths.logs_dir / "retryable-start-failures.jsonl").write_text(
+                json.dumps(
+                    {
+                        "started_at": "2026-04-10T23:59:00Z",
+                        "issue_number": 40,
+                        "branch": retryable_state.branch,
+                        "phase": "start",
+                        "agent_identity": config.agent_identity,
+                        "run_id": "run-123",
+                        "retryable_local_only": True,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            fake_client = FakeGitHubClient(
+                issue_number=40,
+                title="[TASK] recover local-only mission を実装する",
+                labels=[config.labels["working"]],
+            )
+
+            with patch("shinobi.mission_start.GitHubClient", return_value=fake_client):
+                started = resume_local_only_mission(
+                    root=root,
+                    store=store,
+                    config=config,
+                    run_id=run_id,
+                    issue={
+                        "number": 40,
+                        "title": "[TASK] recover local-only mission を実装する",
+                        "state": "OPEN",
+                        "labels": [{"name": config.labels["working"]}],
+                    },
+                    state=retryable_state,
+                    now=now,
+                )
+
+            self.assertEqual(started.issue_number, 40)
+            self.assertEqual(started.branch, "feature/issue-40-recover-local-only-mission")
+            self.assertEqual(fake_client.issue_labels, {config.labels["working"]})
+            self.assertEqual(
+                fake_client.label_operations,
+                [("add", 40, (config.labels["working"],))],
+            )
+
     def test_start_mission_normalizes_all_non_risky_state_labels(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2697,15 +2697,21 @@ class CliTest(unittest.TestCase):
                     state.run_id = "previous-run"
                     state.retryable_local_only = True
                     store.save_state(state)
+                    fake_client = FakeGitHubClient(
+                        issue_number=6,
+                        title="[TASK] run start phase",
+                        labels=["shinobi:ready"],
+                    )
 
                     output = io.StringIO()
-                    with patch("shinobi.cli.git_local_branch_exists", return_value=True):
-                        with patch(
-                            "shinobi.cli.git_current_branch",
-                            return_value="feature/issue-6-run-start-phase",
-                        ):
-                            with redirect_stdout(output):
-                                exit_code = cli.main(["run"])
+                    with patch("shinobi.cli.GitHubClient", return_value=fake_client):
+                        with patch("shinobi.cli.git_local_branch_exists", return_value=True):
+                            with patch(
+                                "shinobi.cli.git_current_branch",
+                                return_value="feature/issue-6-run-start-phase",
+                            ):
+                                with redirect_stdout(output):
+                                    exit_code = cli.main(["run"])
 
             self.assertEqual(exit_code, 1)
             self.assertIn(
@@ -2724,6 +2730,12 @@ class CliTest(unittest.TestCase):
                 phase="start",
                 conclusion="aborted",
             ))
+            self.assertEqual(len(fake_client.comments), 1)
+            self.assertIn(
+                "Shinobi cleared an invalid retryable local-only mission record",
+                str(fake_client.comments[0]["body"]),
+            )
+            self.assertIn("retryable start failure record is missing", str(fake_client.comments[0]["body"]))
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
     def test_run_cleans_up_retryable_local_only_state_when_current_branch_differs(self) -> None:
@@ -2756,15 +2768,21 @@ class CliTest(unittest.TestCase):
                         + "\n",
                         encoding="utf-8",
                     )
+                    fake_client = FakeGitHubClient(
+                        issue_number=6,
+                        title="[TASK] run start phase",
+                        labels=["shinobi:ready"],
+                    )
 
                     output = io.StringIO()
-                    with patch("shinobi.cli.git_local_branch_exists", return_value=True):
-                        with patch(
-                            "shinobi.cli.git_current_branch",
-                            return_value="feature/issue-999-other-work",
-                        ):
-                            with redirect_stdout(output):
-                                exit_code = cli.main(["run"])
+                    with patch("shinobi.cli.GitHubClient", return_value=fake_client):
+                        with patch("shinobi.cli.git_local_branch_exists", return_value=True):
+                            with patch(
+                                "shinobi.cli.git_current_branch",
+                                return_value="feature/issue-999-other-work",
+                            ):
+                                with redirect_stdout(output):
+                                    exit_code = cli.main(["run"])
 
             self.assertEqual(exit_code, 1)
             self.assertIn(
@@ -2787,7 +2805,53 @@ class CliTest(unittest.TestCase):
                     conclusion="aborted",
                 ),
             )
+            self.assertEqual(len(fake_client.comments), 1)
+            self.assertIn(
+                "feature/issue-999-other-work != feature/issue-6-run-start-phase",
+                str(fake_client.comments[0]["body"]),
+            )
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
+
+    def test_cleanup_retryable_local_only_state_reports_state_persistence_failure(self) -> None:
+        state = State(
+            issue_number=6,
+            pr_number=None,
+            branch="feature/issue-6-run-start-phase",
+            agent_identity="owner/repo#default@test",
+            run_id="run-123",
+            phase="start",
+            review_loop_count=0,
+            retryable_local_only=True,
+            lease_expires_at=None,
+            last_result="start_pending",
+            last_error=None,
+        )
+        store = Mock(spec=StateStore)
+        store.save_state.side_effect = OSError("disk full")
+        config = Config(
+            repo="owner/repo",
+            main_branch="main",
+            agent_identity="owner/repo#default@test",
+            mission_lease_minutes=30,
+            mission_heartbeat_interval_minutes=5,
+            max_review_loops=3,
+            labels={},
+            verification_commands={},
+        )
+
+        cleanup_error = cli.cleanup_retryable_local_only_state(
+            root=Path("/tmp/repo"),
+            store=store,
+            config=config,
+            state=state,
+            conclusion="aborted",
+            error="retryable start failure record is missing",
+        )
+
+        self.assertEqual(
+            cleanup_error,
+            "failed to clear retryable local-only state: disk full",
+        )
 
     def test_run_cleans_up_invalid_retryable_local_only_state_before_conflicting_issue_check(
         self,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2358,6 +2358,103 @@ class CliTest(unittest.TestCase):
             start_mock.assert_not_called()
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
+    def test_run_with_issue_resumes_retryable_local_only_mission_when_same_issue_is_active(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    state = store.load_state()
+                    state.issue_number = 6
+                    state.phase = "start"
+                    state.branch = "feature/issue-6-run-start-phase"
+                    state.run_id = "previous-run"
+                    state.retryable_local_only = True
+                    store.save_state(state)
+                    (store.paths.logs_dir / "retryable-start-failures.jsonl").write_text(
+                        json.dumps(
+                            {
+                                "issue_number": 6,
+                                "branch": state.branch,
+                                "phase": "start",
+                                "agent_identity": state.agent_identity,
+                                "run_id": "previous-run",
+                                "retryable_local_only": True,
+                            }
+                        )
+                        + "\n",
+                        encoding="utf-8",
+                    )
+
+                    output = io.StringIO()
+                    with patch("shinobi.cli.list_open_issues_with_any_label", return_value=[6]):
+                        with patch("shinobi.cli.ensure_open_issue", return_value=6) as issue_mock:
+                            with patch(
+                                "shinobi.cli.git_local_branch_exists",
+                                return_value=True,
+                            ):
+                                with patch(
+                                    "shinobi.cli.load_issue",
+                                    return_value={
+                                        "number": 6,
+                                        "title": "Run start phase",
+                                        "state": "OPEN",
+                                        "labels": [{"name": "shinobi:working"}],
+                                    },
+                                ):
+                                    with patch(
+                                        "shinobi.cli.resume_local_only_mission",
+                                        return_value=Mock(
+                                            branch="feature/issue-6-run-start-phase",
+                                            issue_number=6,
+                                            lease_expires_at="2026-04-09T00:30:00Z",
+                                        ),
+                                    ) as resume_mock:
+                                        execution_result = Mock()
+                                        execution_result.succeeded = True
+                                        execution_result.commands = []
+                                        with patch(
+                                            "shinobi.cli.execute_verification",
+                                            return_value=execution_result,
+                                        ):
+                                            with patch(
+                                                "shinobi.cli.load_publishable_issue_label_names",
+                                                return_value={"shinobi:working"},
+                                            ):
+                                                with patch(
+                                                    "shinobi.cli.detect_high_risk_stop",
+                                                    return_value=None,
+                                                ):
+                                                    with patch(
+                                                        "shinobi.cli.publish_mission",
+                                                        return_value=Mock(
+                                                            pr_number=31,
+                                                            pr_url=None,
+                                                            lease_expires_at=(
+                                                                "2026-04-09T00:30:00Z"
+                                                            ),
+                                                        ),
+                                                    ):
+                                                        with redirect_stdout(output):
+                                                            exit_code = cli.main(
+                                                                ["run", "--issue", "6"]
+                                                            )
+
+            self.assertEqual(exit_code, 0)
+            self.assertIn("selected_issue: 6", output.getvalue())
+            issue_mock.assert_called_once_with(
+                root,
+                6,
+                active_labels=("shinobi:working", "shinobi:reviewing"),
+                allow_active_labels=True,
+                repo="owner/repo",
+            )
+            resume_mock.assert_called_once()
+            self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
+
     def test_run_with_issue_refuses_same_issue_when_github_mission_is_active(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2305,52 +2305,56 @@ class CliTest(unittest.TestCase):
                                 return_value=True,
                             ):
                                 with patch(
-                                    "shinobi.cli.load_issue",
-                                    return_value={
-                                        "number": 6,
-                                        "title": "Run start phase",
-                                        "state": "OPEN",
-                                        "labels": [{"name": "shinobi:ready"}],
-                                    },
+                                    "shinobi.cli.git_current_branch",
+                                    return_value="feature/issue-6-run-start-phase",
                                 ):
                                     with patch(
-                                        "shinobi.cli.resume_local_only_mission",
-                                        return_value=Mock(
-                                            branch="feature/issue-6-run-start-phase",
-                                            issue_number=6,
-                                            lease_expires_at="2026-04-09T00:30:00Z",
-                                        ),
-                                    ) as resume_mock:
-                                        with patch("shinobi.cli.start_mission") as start_mock:
-                                            execution_result = Mock()
-                                            execution_result.succeeded = True
-                                            execution_result.commands = []
-                                            with patch(
-                                                "shinobi.cli.execute_verification",
-                                                return_value=execution_result,
-                                            ):
+                                        "shinobi.cli.load_issue",
+                                        return_value={
+                                            "number": 6,
+                                            "title": "Run start phase",
+                                            "state": "OPEN",
+                                            "labels": [{"name": "shinobi:ready"}],
+                                        },
+                                    ):
+                                        with patch(
+                                            "shinobi.cli.resume_local_only_mission",
+                                            return_value=Mock(
+                                                branch="feature/issue-6-run-start-phase",
+                                                issue_number=6,
+                                                lease_expires_at="2026-04-09T00:30:00Z",
+                                            ),
+                                        ) as resume_mock:
+                                            with patch("shinobi.cli.start_mission") as start_mock:
+                                                execution_result = Mock()
+                                                execution_result.succeeded = True
+                                                execution_result.commands = []
                                                 with patch(
-                                                    "shinobi.cli.load_publishable_issue_label_names",
-                                                    return_value={"shinobi:working"},
+                                                    "shinobi.cli.execute_verification",
+                                                    return_value=execution_result,
                                                 ):
                                                     with patch(
-                                                        "shinobi.cli.detect_high_risk_stop",
-                                                        return_value=None,
+                                                        "shinobi.cli.load_publishable_issue_label_names",
+                                                        return_value={"shinobi:working"},
                                                     ):
                                                         with patch(
-                                                            "shinobi.cli.publish_mission",
-                                                            return_value=Mock(
-                                                                pr_number=31,
-                                                                pr_url=None,
-                                                                lease_expires_at=(
-                                                                    "2026-04-09T00:30:00Z"
-                                                                ),
-                                                            ),
+                                                            "shinobi.cli.detect_high_risk_stop",
+                                                            return_value=None,
                                                         ):
-                                                            with redirect_stdout(output):
-                                                                exit_code = cli.main(
-                                                                    ["run", "--issue", "6"]
-                                                                )
+                                                            with patch(
+                                                                "shinobi.cli.publish_mission",
+                                                                return_value=Mock(
+                                                                    pr_number=31,
+                                                                    pr_url=None,
+                                                                    lease_expires_at=(
+                                                                        "2026-04-09T00:30:00Z"
+                                                                    ),
+                                                                ),
+                                                            ):
+                                                                with redirect_stdout(output):
+                                                                    exit_code = cli.main(
+                                                                        ["run", "--issue", "6"]
+                                                                    )
 
             self.assertEqual(exit_code, 0)
             self.assertIn("selected_issue: 6", output.getvalue())
@@ -2397,51 +2401,55 @@ class CliTest(unittest.TestCase):
                                 return_value=True,
                             ):
                                 with patch(
-                                    "shinobi.cli.load_issue",
-                                    return_value={
-                                        "number": 6,
-                                        "title": "Run start phase",
-                                        "state": "OPEN",
-                                        "labels": [{"name": "shinobi:working"}],
-                                    },
+                                    "shinobi.cli.git_current_branch",
+                                    return_value="feature/issue-6-run-start-phase",
                                 ):
                                     with patch(
-                                        "shinobi.cli.resume_local_only_mission",
-                                        return_value=Mock(
-                                            branch="feature/issue-6-run-start-phase",
-                                            issue_number=6,
-                                            lease_expires_at="2026-04-09T00:30:00Z",
-                                        ),
-                                    ) as resume_mock:
-                                        execution_result = Mock()
-                                        execution_result.succeeded = True
-                                        execution_result.commands = []
+                                        "shinobi.cli.load_issue",
+                                        return_value={
+                                            "number": 6,
+                                            "title": "Run start phase",
+                                            "state": "OPEN",
+                                            "labels": [{"name": "shinobi:working"}],
+                                        },
+                                    ):
                                         with patch(
-                                            "shinobi.cli.execute_verification",
-                                            return_value=execution_result,
-                                        ):
+                                            "shinobi.cli.resume_local_only_mission",
+                                            return_value=Mock(
+                                                branch="feature/issue-6-run-start-phase",
+                                                issue_number=6,
+                                                lease_expires_at="2026-04-09T00:30:00Z",
+                                            ),
+                                        ) as resume_mock:
+                                            execution_result = Mock()
+                                            execution_result.succeeded = True
+                                            execution_result.commands = []
                                             with patch(
-                                                "shinobi.cli.load_publishable_issue_label_names",
-                                                return_value={"shinobi:working"},
+                                                "shinobi.cli.execute_verification",
+                                                return_value=execution_result,
                                             ):
                                                 with patch(
-                                                    "shinobi.cli.detect_high_risk_stop",
-                                                    return_value=None,
+                                                    "shinobi.cli.load_publishable_issue_label_names",
+                                                    return_value={"shinobi:working"},
                                                 ):
                                                     with patch(
-                                                        "shinobi.cli.publish_mission",
-                                                        return_value=Mock(
-                                                            pr_number=31,
-                                                            pr_url=None,
-                                                            lease_expires_at=(
-                                                                "2026-04-09T00:30:00Z"
-                                                            ),
-                                                        ),
+                                                        "shinobi.cli.detect_high_risk_stop",
+                                                        return_value=None,
                                                     ):
-                                                        with redirect_stdout(output):
-                                                            exit_code = cli.main(
-                                                                ["run", "--issue", "6"]
-                                                            )
+                                                        with patch(
+                                                            "shinobi.cli.publish_mission",
+                                                            return_value=Mock(
+                                                                pr_number=31,
+                                                                pr_url=None,
+                                                                lease_expires_at=(
+                                                                    "2026-04-09T00:30:00Z"
+                                                                ),
+                                                            ),
+                                                        ):
+                                                            with redirect_stdout(output):
+                                                                exit_code = cli.main(
+                                                                    ["run", "--issue", "6"]
+                                                                )
 
             self.assertEqual(exit_code, 0)
             self.assertIn("selected_issue: 6", output.getvalue())
@@ -2671,8 +2679,12 @@ class CliTest(unittest.TestCase):
 
                     output = io.StringIO()
                     with patch("shinobi.cli.git_local_branch_exists", return_value=True):
-                        with redirect_stdout(output):
-                            exit_code = cli.main(["run"])
+                        with patch(
+                            "shinobi.cli.git_current_branch",
+                            return_value="feature/issue-6-run-start-phase",
+                        ):
+                            with redirect_stdout(output):
+                                exit_code = cli.main(["run"])
 
             self.assertEqual(exit_code, 1)
             self.assertIn(
@@ -2691,6 +2703,69 @@ class CliTest(unittest.TestCase):
                 phase="start",
                 conclusion="aborted",
             ))
+            self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
+
+    def test_run_cleans_up_retryable_local_only_state_when_current_branch_differs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    state = store.load_state()
+                    state.issue_number = 6
+                    state.phase = "start"
+                    state.branch = "feature/issue-6-run-start-phase"
+                    state.run_id = "previous-run"
+                    state.retryable_local_only = True
+                    store.save_state(state)
+                    (store.paths.logs_dir / "retryable-start-failures.jsonl").write_text(
+                        json.dumps(
+                            {
+                                "issue_number": 6,
+                                "branch": state.branch,
+                                "phase": "start",
+                                "agent_identity": state.agent_identity,
+                                "run_id": "previous-run",
+                                "retryable_local_only": True,
+                            }
+                        )
+                        + "\n",
+                        encoding="utf-8",
+                    )
+
+                    output = io.StringIO()
+                    with patch("shinobi.cli.git_local_branch_exists", return_value=True):
+                        with patch(
+                            "shinobi.cli.git_current_branch",
+                            return_value="feature/issue-999-other-work",
+                        ):
+                            with redirect_stdout(output):
+                                exit_code = cli.main(["run"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn(
+                "run aborted: retryable local-only mission for issue #6 could not be resumed: "
+                "current branch does not match retryable local-only branch "
+                "(feature/issue-999-other-work != feature/issue-6-run-start-phase)",
+                output.getvalue(),
+            )
+            repaired_state = store.load_state()
+            self.assertEqual(repaired_state.phase, "idle")
+            self.assertFalse(repaired_state.retryable_local_only)
+            self.assertEqual(repaired_state.last_result, "aborted")
+            self.assertEqual(
+                repaired_state.last_mission,
+                MissionSummary(
+                    issue_number=6,
+                    pr_number=None,
+                    branch="feature/issue-6-run-start-phase",
+                    phase="start",
+                    conclusion="aborted",
+                ),
+            )
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
     def test_select_ready_issue_prefers_high_priority_labels(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2883,6 +2883,65 @@ class CliTest(unittest.TestCase):
             )
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
+    def test_run_cleans_up_foreign_retryable_local_only_state_without_github_comment(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, _ = store.try_load_config()
+                    assert config is not None
+                    state = store.load_state()
+                    state.issue_number = 6
+                    state.phase = "start"
+                    state.branch = "feature/issue-6-run-start-phase"
+                    state.run_id = "previous-run"
+                    state.agent_identity = "other/repo#default@test"
+                    state.retryable_local_only = True
+                    store.save_state(state)
+                    (store.paths.logs_dir / "retryable-start-failures.jsonl").write_text(
+                        json.dumps(
+                            {
+                                "issue_number": 6,
+                                "branch": state.branch,
+                                "phase": "start",
+                                "agent_identity": state.agent_identity,
+                                "run_id": "previous-run",
+                                "retryable_local_only": True,
+                            }
+                        )
+                        + "\n",
+                        encoding="utf-8",
+                    )
+                    fake_client = FakeGitHubClient(
+                        issue_number=6,
+                        title="[TASK] run start phase",
+                        labels=["shinobi:ready"],
+                    )
+
+                    output = io.StringIO()
+                    with patch("shinobi.cli.GitHubClient", return_value=fake_client):
+                        with redirect_stdout(output):
+                            exit_code = cli.main(["run"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn(
+                "run aborted: retryable local-only mission for issue #6 could not be resumed: "
+                "agent_identity does not match current workspace "
+                f"(other/repo#default@test != {config.agent_identity})",
+                output.getvalue(),
+            )
+            repaired_state = store.load_state()
+            self.assertEqual(repaired_state.phase, "idle")
+            self.assertFalse(repaired_state.retryable_local_only)
+            self.assertEqual(repaired_state.agent_identity, config.agent_identity)
+            self.assertEqual(repaired_state.last_result, "aborted")
+            self.assertEqual(len(fake_client.comments), 0)
+            self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
+
     def test_cleanup_retryable_local_only_state_reports_state_persistence_failure(self) -> None:
         state = State(
             issue_number=6,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,6 +44,7 @@ from shinobi.mission_start import (
     MissionStartError,
     StartedMission,
     handoff_started_mission,
+    resume_local_only_mission,
     start_mission,
 )
 from shinobi.models import (
@@ -2265,7 +2266,7 @@ class CliTest(unittest.TestCase):
             issue_mock.assert_not_called()
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
-    def test_run_with_issue_refuses_same_issue_when_retryable_local_only_mission_exists(self) -> None:
+    def test_run_with_issue_resumes_same_retryable_local_only_mission(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)
             with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
@@ -2277,21 +2278,84 @@ class CliTest(unittest.TestCase):
                     state = store.load_state()
                     state.issue_number = 6
                     state.phase = "start"
+                    state.branch = "feature/issue-6-run-start-phase"
+                    state.run_id = "previous-run"
                     state.retryable_local_only = True
                     store.save_state(state)
+                    (store.paths.logs_dir / "retryable-start-failures.jsonl").write_text(
+                        json.dumps(
+                            {
+                                "issue_number": 6,
+                                "branch": state.branch,
+                                "phase": "start",
+                                "agent_identity": state.agent_identity,
+                                "run_id": "previous-run",
+                                "retryable_local_only": True,
+                            }
+                        )
+                        + "\n",
+                        encoding="utf-8",
+                    )
 
                     output = io.StringIO()
                     with patch("shinobi.cli.list_open_issues_with_any_label", return_value=[]):
-                        with patch("shinobi.cli.ensure_open_issue", return_value=6) as issue_mock:
-                            with redirect_stdout(output):
-                                exit_code = cli.main(["run", "--issue", "6"])
+                        with patch("shinobi.cli.ensure_open_issue", return_value=6):
+                            with patch(
+                                "shinobi.cli.git_local_branch_exists",
+                                return_value=True,
+                            ):
+                                with patch(
+                                    "shinobi.cli.load_issue",
+                                    return_value={
+                                        "number": 6,
+                                        "title": "Run start phase",
+                                        "state": "OPEN",
+                                        "labels": [{"name": "shinobi:ready"}],
+                                    },
+                                ):
+                                    with patch(
+                                        "shinobi.cli.resume_local_only_mission",
+                                        return_value=Mock(
+                                            branch="feature/issue-6-run-start-phase",
+                                            issue_number=6,
+                                            lease_expires_at="2026-04-09T00:30:00Z",
+                                        ),
+                                    ) as resume_mock:
+                                        with patch("shinobi.cli.start_mission") as start_mock:
+                                            execution_result = Mock()
+                                            execution_result.succeeded = True
+                                            execution_result.commands = []
+                                            with patch(
+                                                "shinobi.cli.execute_verification",
+                                                return_value=execution_result,
+                                            ):
+                                                with patch(
+                                                    "shinobi.cli.load_publishable_issue_label_names",
+                                                    return_value={"shinobi:working"},
+                                                ):
+                                                    with patch(
+                                                        "shinobi.cli.detect_high_risk_stop",
+                                                        return_value=None,
+                                                    ):
+                                                        with patch(
+                                                            "shinobi.cli.publish_mission",
+                                                            return_value=Mock(
+                                                                pr_number=31,
+                                                                pr_url=None,
+                                                                lease_expires_at=(
+                                                                    "2026-04-09T00:30:00Z"
+                                                                ),
+                                                            ),
+                                                        ):
+                                                            with redirect_stdout(output):
+                                                                exit_code = cli.main(
+                                                                    ["run", "--issue", "6"]
+                                                                )
 
-            self.assertEqual(exit_code, 1)
-            self.assertIn(
-                "run aborted: retryable local-only mission exists for issue #6",
-                output.getvalue(),
-            )
-            issue_mock.assert_not_called()
+            self.assertEqual(exit_code, 0)
+            self.assertIn("selected_issue: 6", output.getvalue())
+            resume_mock.assert_called_once()
+            start_mock.assert_not_called()
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
     def test_run_with_issue_refuses_same_issue_when_github_mission_is_active(self) -> None:
@@ -2485,6 +2549,51 @@ class CliTest(unittest.TestCase):
                 "run aborted: retryable local-only mission exists but local state is missing issue_number",
                 output.getvalue(),
             )
+            repaired_state = store.load_state()
+            self.assertEqual(repaired_state.phase, "idle")
+            self.assertFalse(repaired_state.retryable_local_only)
+            self.assertEqual(repaired_state.last_result, "aborted")
+            self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
+
+    def test_run_cleans_up_retryable_local_only_state_without_retry_log(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    state = store.load_state()
+                    state.issue_number = 6
+                    state.phase = "start"
+                    state.branch = "feature/issue-6-run-start-phase"
+                    state.run_id = "previous-run"
+                    state.retryable_local_only = True
+                    store.save_state(state)
+
+                    output = io.StringIO()
+                    with patch("shinobi.cli.git_local_branch_exists", return_value=True):
+                        with redirect_stdout(output):
+                            exit_code = cli.main(["run"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn(
+                "run aborted: retryable local-only mission for issue #6 could not be resumed: "
+                "retryable start failure record is missing",
+                output.getvalue(),
+            )
+            repaired_state = store.load_state()
+            self.assertEqual(repaired_state.phase, "idle")
+            self.assertFalse(repaired_state.retryable_local_only)
+            self.assertEqual(repaired_state.last_result, "aborted")
+            self.assertEqual(repaired_state.last_mission, MissionSummary(
+                issue_number=6,
+                pr_number=None,
+                branch="feature/issue-6-run-start-phase",
+                phase="start",
+                conclusion="aborted",
+            ))
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
     def test_select_ready_issue_prefers_high_priority_labels(self) -> None:
@@ -3193,6 +3302,87 @@ class MissionStartTest(unittest.TestCase):
             self.assertEqual(payload["phase"], "start")
             self.assertTrue(payload["retryable_local_only"])
             self.assertIn("disk full", payload["last_error"])
+
+    def test_resume_local_only_mission_completes_start_transition(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            store = StateStore(root)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                config, _ = store.initialize()
+
+            run_id = "run-456"
+            now = datetime(2026, 4, 11, 0, 0, tzinfo=timezone.utc)
+            store.save_lock(store.acquire_lock(config=config, run_id=run_id, pid=123, now=now)[0])
+            retryable_state = State(
+                issue_number=40,
+                pr_number=None,
+                branch="feature/issue-40-recover-local-only-mission",
+                agent_identity=config.agent_identity,
+                run_id="run-123",
+                phase="start",
+                review_loop_count=0,
+                retryable_local_only=True,
+                lease_expires_at=None,
+                last_result="start_pending",
+                last_error="persist failed once",
+            )
+            store.save_state(retryable_state)
+            (store.paths.logs_dir / "retryable-start-failures.jsonl").write_text(
+                json.dumps(
+                    {
+                        "started_at": "2026-04-10T23:59:00Z",
+                        "issue_number": 40,
+                        "branch": retryable_state.branch,
+                        "phase": "start",
+                        "agent_identity": config.agent_identity,
+                        "run_id": "run-123",
+                        "retryable_local_only": True,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            fake_client = FakeGitHubClient(
+                issue_number=40,
+                title="[TASK] recover local-only mission を実装する",
+                labels=[config.labels["ready"]],
+            )
+
+            with patch("shinobi.mission_start.GitHubClient", return_value=fake_client):
+                started = resume_local_only_mission(
+                    root=root,
+                    store=store,
+                    config=config,
+                    run_id=run_id,
+                    issue={
+                        "number": 40,
+                        "title": "[TASK] recover local-only mission を実装する",
+                        "state": "OPEN",
+                        "labels": [{"name": config.labels["ready"]}],
+                    },
+                    state=retryable_state,
+                    now=now,
+                )
+
+            self.assertEqual(started.issue_number, 40)
+            self.assertEqual(started.branch, "feature/issue-40-recover-local-only-mission")
+            self.assertEqual(fake_client.issue_labels, {config.labels["working"]})
+            self.assertEqual(
+                fake_client.label_operations,
+                [
+                    ("add", 40, (config.labels["working"],)),
+                    ("remove", 40, (config.labels["ready"],)),
+                ],
+            )
+            self.assertEqual(len(fake_client.comments), 1)
+            self.assertIn("Shinobi Start", str(fake_client.comments[0]["body"]))
+            saved_state = store.load_state()
+            self.assertEqual(saved_state.phase, "start")
+            self.assertFalse(saved_state.retryable_local_only)
+            self.assertEqual(saved_state.run_id, run_id)
+            self.assertEqual(saved_state.branch, retryable_state.branch)
+            self.assertEqual(saved_state.last_result, "started")
+            self.assertIsNone(saved_state.last_error)
 
     def test_start_mission_normalizes_all_non_risky_state_labels(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2567,12 +2567,33 @@ class CliTest(unittest.TestCase):
                     state = store.load_state()
                     state.issue_number = 5
                     state.phase = "start"
+                    state.branch = "feature/issue-5-existing-retryable-mission"
+                    state.run_id = "previous-run"
                     state.retryable_local_only = True
                     store.save_state(state)
+                    (store.paths.logs_dir / "retryable-start-failures.jsonl").write_text(
+                        json.dumps(
+                            {
+                                "issue_number": 5,
+                                "branch": state.branch,
+                                "phase": "start",
+                                "agent_identity": state.agent_identity,
+                                "run_id": "previous-run",
+                                "retryable_local_only": True,
+                            }
+                        )
+                        + "\n",
+                        encoding="utf-8",
+                    )
 
                     output = io.StringIO()
-                    with redirect_stdout(output):
-                        exit_code = cli.main(["run", "--issue", "6"])
+                    with patch("shinobi.cli.git_local_branch_exists", return_value=True):
+                        with patch(
+                            "shinobi.cli.git_current_branch",
+                            return_value="feature/issue-5-existing-retryable-mission",
+                        ):
+                            with redirect_stdout(output):
+                                exit_code = cli.main(["run", "--issue", "6"])
 
             self.assertEqual(exit_code, 1)
             self.assertIn(
@@ -2750,6 +2771,56 @@ class CliTest(unittest.TestCase):
                 "run aborted: retryable local-only mission for issue #6 could not be resumed: "
                 "current branch does not match retryable local-only branch "
                 "(feature/issue-999-other-work != feature/issue-6-run-start-phase)",
+                output.getvalue(),
+            )
+            repaired_state = store.load_state()
+            self.assertEqual(repaired_state.phase, "idle")
+            self.assertFalse(repaired_state.retryable_local_only)
+            self.assertEqual(repaired_state.last_result, "aborted")
+            self.assertEqual(
+                repaired_state.last_mission,
+                MissionSummary(
+                    issue_number=6,
+                    pr_number=None,
+                    branch="feature/issue-6-run-start-phase",
+                    phase="start",
+                    conclusion="aborted",
+                ),
+            )
+            self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
+
+    def test_run_cleans_up_invalid_retryable_local_only_state_before_conflicting_issue_check(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    state = store.load_state()
+                    state.issue_number = 6
+                    state.phase = "start"
+                    state.branch = "feature/issue-6-run-start-phase"
+                    state.run_id = "previous-run"
+                    state.retryable_local_only = True
+                    store.save_state(state)
+
+                    output = io.StringIO()
+                    with patch("shinobi.cli.git_local_branch_exists", return_value=True):
+                        with patch(
+                            "shinobi.cli.git_current_branch",
+                            return_value="feature/issue-6-run-start-phase",
+                        ):
+                            with redirect_stdout(output):
+                                exit_code = cli.main(["run", "--issue", "7"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn(
+                "run aborted: retryable local-only mission for issue #6 could not be resumed: "
+                "retryable start failure record is missing",
                 output.getvalue(),
             )
             repaired_state = store.load_state()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2812,6 +2812,77 @@ class CliTest(unittest.TestCase):
             )
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
 
+    def test_run_cleans_up_retryable_local_only_state_when_head_is_detached(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    state = store.load_state()
+                    state.issue_number = 6
+                    state.phase = "start"
+                    state.branch = "feature/issue-6-run-start-phase"
+                    state.run_id = "previous-run"
+                    state.retryable_local_only = True
+                    store.save_state(state)
+                    (store.paths.logs_dir / "retryable-start-failures.jsonl").write_text(
+                        json.dumps(
+                            {
+                                "issue_number": 6,
+                                "branch": state.branch,
+                                "phase": "start",
+                                "agent_identity": state.agent_identity,
+                                "run_id": "previous-run",
+                                "retryable_local_only": True,
+                            }
+                        )
+                        + "\n",
+                        encoding="utf-8",
+                    )
+                    fake_client = FakeGitHubClient(
+                        issue_number=6,
+                        title="[TASK] run start phase",
+                        labels=["shinobi:ready"],
+                    )
+
+                    output = io.StringIO()
+                    with patch("shinobi.cli.GitHubClient", return_value=fake_client):
+                        with patch("shinobi.cli.git_local_branch_exists", return_value=True):
+                            with patch("shinobi.cli.git_current_branch", return_value=None):
+                                with redirect_stdout(output):
+                                    exit_code = cli.main(["run"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn(
+                "run aborted: retryable local-only mission for issue #6 could not be resumed: "
+                "current branch does not match retryable local-only branch "
+                "(detached HEAD != feature/issue-6-run-start-phase)",
+                output.getvalue(),
+            )
+            repaired_state = store.load_state()
+            self.assertEqual(repaired_state.phase, "idle")
+            self.assertFalse(repaired_state.retryable_local_only)
+            self.assertEqual(repaired_state.last_result, "aborted")
+            self.assertEqual(
+                repaired_state.last_mission,
+                MissionSummary(
+                    issue_number=6,
+                    pr_number=None,
+                    branch="feature/issue-6-run-start-phase",
+                    phase="start",
+                    conclusion="aborted",
+                ),
+            )
+            self.assertEqual(len(fake_client.comments), 1)
+            self.assertIn(
+                "detached HEAD != feature/issue-6-run-start-phase",
+                str(fake_client.comments[0]["body"]),
+            )
+            self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
+
     def test_cleanup_retryable_local_only_state_reports_state_persistence_failure(self) -> None:
         state = State(
             issue_number=6,


### PR DESCRIPTION
## Summary
- resume retryable local-only missions only when branch state and retry logs match the current workspace identity
- clear invalid local-only state back to idle with mission history instead of treating state alone as recoverable
- add mission-start coverage for local-only resume and align the product spec wording with the new behavior

## Testing
- python3 -m unittest tests.test_cli.CliTest tests.test_cli.MissionStartTest
- python3 -m unittest tests.test_cli
- env PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m compileall src tests

Closes #38
