### PR TITLE
Implement merge phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ shinobi run --issue 123
 shinobi review
 ```
 
-`watch` や merge などの後続コマンドは将来候補です。
+`watch` などの後続コマンドは将来候補です。
 
 現在の実装では foundations に加えて、`shinobi run` / `shinobi run --issue <id>` の select / start / publish phase と、`shinobi review` の CI polling / retry / auto-merge 判定が動作します。Issue 選択、`.shinobi/run.lock` によるローカル排他、`feature/issue-<id>-<slug>` branch 作成、start 用の machine-readable comment 投稿、検証コマンド実行、branch push、draft PR 作成または更新、publish 用の label / mission-state comment 更新、review phase の CI 待機、retry state 保存、安全条件を満たす PR の squash merge と finalize まで実装済みです。context builder の run phase 統合と、AI による review loop の自動修正は未実装です。
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ shinobi review
 
 `watch` や merge などの後続コマンドは将来候補です。
 
-現在の実装では foundations に加えて、`shinobi run` / `shinobi run --issue <id>` の select / start / publish phase と、`shinobi review` の CI polling / retry 判定が動作します。Issue 選択、`.shinobi/run.lock` によるローカル排他、`feature/issue-<id>-<slug>` branch 作成、start 用の machine-readable comment 投稿、検証コマンド実行、branch push、draft PR 作成または更新、publish 用の label / mission-state comment 更新、review phase の CI 待機結果と retry state の保存まで実装済みです。context builder の run phase 統合、AI による review loop の自動修正、auto-merge は未実装です。
+現在の実装では foundations に加えて、`shinobi run` / `shinobi run --issue <id>` の select / start / publish phase と、`shinobi review` の CI polling / retry / auto-merge 判定が動作します。Issue 選択、`.shinobi/run.lock` によるローカル排他、`feature/issue-<id>-<slug>` branch 作成、start 用の machine-readable comment 投稿、検証コマンド実行、branch push、draft PR 作成または更新、publish 用の label / mission-state comment 更新、review phase の CI 待機、retry state 保存、安全条件を満たす PR の squash merge と finalize まで実装済みです。context builder の run phase 統合と、AI による review loop の自動修正は未実装です。
 
 ## ドキュメント構成
 
@@ -88,4 +88,4 @@ shinobi review
 
 ## 現在の状態
 
-このリポジトリは foundations 実装に加え、`run` の start / publish phase、`review` の CI polling / retry 判定、context builder を持ちます。現在は `.shinobi/` の初期化、ローカル state/config の保存、`status` のローカル表示と GitHub 照合、`run` の issue 選択、stale/live lock 判定、branch 作成、start 用 comment 投稿、GitHub label の start 遷移、検証コマンド実行、branch push、draft PR 作成または更新、publish 用 comment / label / state 更新、review 用の CI 状態取得、retry state 保存、上限到達時の `needs-human` finalize、Issue 由来の最小 context 構築までを持ちます。context phase の run 統合、AI による review loop の自動修正、自動 merge はこれから実装します。
+このリポジトリは foundations 実装に加え、`run` の start / publish phase、`review` の CI polling / retry / merge 判定、context builder を持ちます。現在は `.shinobi/` の初期化、ローカル state/config の保存、`status` のローカル表示と GitHub 照合、`run` の issue 選択、stale/live lock 判定、branch 作成、start 用 comment 投稿、GitHub label の start 遷移、検証コマンド実行、branch push、draft PR 作成または更新、publish 用 comment / label / state 更新、review 用の CI 状態取得、retry state 保存、安全条件を満たす PR の squash merge、finalize、Issue 由来の最小 context 構築までを持ちます。context phase の run 統合と、AI による review loop の自動修正はこれから実装します。

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import subprocess
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -407,6 +408,17 @@ def command_review(
         print(
             "review aborted: local mission state belongs to a different agent "
             f"({state.agent_identity})"
+        )
+        return 1
+    try:
+        current_branch = load_current_branch(root)
+    except RuntimeError as error:
+        print(f"review aborted: {error}")
+        return 1
+    if current_branch != state.branch:
+        print(
+            "review aborted: current git branch "
+            f"{current_branch} does not match mission branch {state.branch}"
         )
         return 1
 
@@ -953,6 +965,30 @@ def require_review_branch(state: State) -> str:
     if not state.branch:
         raise ReviewerError("review retry requires branch")
     return state.branch
+
+
+def load_current_branch(root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as error:
+        raise RuntimeError(f"failed to resolve current git branch: {error}") from error
+
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or f"git exited with {result.returncode}"
+        raise RuntimeError(f"failed to resolve current git branch: {message}")
+
+    branch = result.stdout.strip()
+    if not branch:
+        raise RuntimeError("failed to resolve current git branch: git returned an empty branch name")
+    if branch == "HEAD":
+        raise RuntimeError("current git checkout is detached; review requires the mission branch")
+    return branch
 
 
 def build_review_state(

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -35,8 +35,9 @@ from .mission_start import (
     handoff_started_mission,
     start_mission,
 )
+from .merger import MergerError, evaluate_merge, merge_pull_request
 from .models import Config, ExecutionResult, State, StopDecision
-from .reviewer import ReviewerError, wait_for_ci
+from .reviewer import ReviewerError, collect_diff_stats, wait_for_ci
 from .state_store import StateStore
 
 
@@ -517,6 +518,11 @@ def command_review(
         completed_lease_expires_at = store.format_timestamp(
             completed_at + timedelta(minutes=config.mission_lease_minutes)
         )
+        rendered_checks = (
+            ", ".join(f"{check.name}={check.bucket}" for check in ci_status.checks)
+            if ci_status.checks
+            else "none"
+        )
         if ci_status.is_failed:
             try:
                 return handle_failed_ci_review(
@@ -545,62 +551,163 @@ def command_review(
                 print(f"review aborted: failed to persist CI review retry result: {error}")
                 return 1
 
-        review_state = State(
-            issue_number=state.issue_number,
-            pr_number=state.pr_number,
-            branch=state.branch,
-            agent_identity=config.agent_identity,
-            run_id=run_id,
-            phase="review",
-            review_loop_count=state.review_loop_count,
-            retryable_local_only=False,
-            lease_expires_at=completed_lease_expires_at,
-            last_result=render_review_result(ci_status),
-            last_error="CI polling timed out before checks completed" if ci_status.timed_out else None,
-            last_mission=state.last_mission,
-            extra={
-                **state.extra,
-                "ci_status": {
-                    "status": ci_status.status,
-                    "timed_out": ci_status.timed_out,
-                    "checks": [
-                        {
-                            "name": check.name,
-                            "state": check.state,
-                            "bucket": check.bucket,
-                            "link": check.link,
-                        }
-                        for check in ci_status.checks
-                    ],
-                },
-            },
-        )
+        if not ci_status.is_successful:
+            review_state = build_review_state(
+                state=state,
+                config=config,
+                run_id=run_id,
+                phase="review",
+                review_loop_count=state.review_loop_count,
+                lease_expires_at=completed_lease_expires_at,
+                last_result=render_review_result(ci_status),
+                last_error="CI polling timed out before checks completed"
+                if ci_status.timed_out
+                else None,
+                ci_status=ci_status,
+            )
+            try:
+                update_review_comment(comment_lease_expires_at=completed_lease_expires_at)
+                store.save_state(review_state)
+            except (ReviewerError, RuntimeError, ValueError) as error:
+                persist_review_error(str(error))
+                print(f"review aborted: {error}")
+                return 1
+            except OSError as error:
+                persist_review_error(f"failed to persist CI review result: {error}")
+                print(f"review aborted: failed to persist CI review result: {error}")
+                return 1
+
+            print(f"review_issue: #{state.issue_number}")
+            print(f"review_pr: #{state.pr_number}")
+            print(f"ci_status: {ci_status.status}")
+            print(f"ci_timed_out: {ci_status.timed_out}")
+            print(f"ci_checks: {rendered_checks}")
+            return 1
+
         try:
             update_review_comment(comment_lease_expires_at=completed_lease_expires_at)
-            store.save_state(review_state)
-        except (ReviewerError, RuntimeError, ValueError) as error:
+            return handle_successful_ci_review(
+                root=root,
+                store=store,
+                config=config,
+                client=client,
+                run_id=run_id,
+                state=state,
+                ci_status=ci_status,
+                lease_expires_at=completed_lease_expires_at,
+                rendered_checks=rendered_checks,
+            )
+        except (
+            MissionFinalizeError,
+            MergerError,
+            ReviewerError,
+            RuntimeError,
+            ValueError,
+        ) as error:
             persist_review_error(str(error))
             print(f"review aborted: {error}")
             return 1
         except OSError as error:
-            persist_review_error(f"failed to persist CI review result: {error}")
-            print(f"review aborted: failed to persist CI review result: {error}")
+            persist_review_error(f"failed to finalize successful CI review: {error}")
+            print(f"review aborted: failed to finalize successful CI review: {error}")
             return 1
-
-        print(f"review_issue: #{state.issue_number}")
-        print(f"review_pr: #{state.pr_number}")
-        print(f"ci_status: {ci_status.status}")
-        print(f"ci_timed_out: {ci_status.timed_out}")
-        if ci_status.checks:
-            print(
-                "ci_checks: "
-                + ", ".join(f"{check.name}={check.bucket}" for check in ci_status.checks)
-            )
-        else:
-            print("ci_checks: none")
-        return 1 if ci_status.timed_out or ci_status.is_failed else 0
     finally:
         store.clear_lock(run_id)
+
+
+def handle_successful_ci_review(
+    *,
+    root: Path,
+    store: StateStore,
+    config: Config,
+    client: GitHubClient,
+    run_id: str,
+    state: State,
+    ci_status: Any,
+    lease_expires_at: str,
+    rendered_checks: str,
+) -> int:
+    issue_number = require_review_issue_number(state)
+    pr_number = require_review_pr_number(state)
+
+    try:
+        issue = client.get_issue(issue_number)
+    except GitHubClientError as error:
+        raise ReviewerError(f"failed to load issue #{issue_number} before merge: {error}") from error
+
+    diff_stats = collect_diff_stats(root, base_ref=config.main_branch)
+    decision = evaluate_merge(
+        config=config,
+        state=state,
+        issue=issue,
+        ci_status=ci_status,
+        diff_stats=diff_stats,
+    )
+    review_state = build_review_state(
+        state=state,
+        config=config,
+        run_id=run_id,
+        phase="review",
+        review_loop_count=state.review_loop_count,
+        lease_expires_at=lease_expires_at,
+        last_result=render_review_result(ci_status),
+        last_error=None,
+        ci_status=ci_status,
+        extra={
+            "merge_decision": {
+                "should_merge": decision.should_merge,
+                "reasons": list(decision.reasons),
+                "diff_stats": {
+                    "changed_files": diff_stats.changed_files,
+                    "added_lines": diff_stats.added_lines,
+                    "deleted_lines": diff_stats.deleted_lines,
+                },
+            }
+        },
+    )
+
+    print(f"review_issue: #{issue_number}")
+    print(f"review_pr: #{pr_number}")
+    print(f"ci_status: {ci_status.status}")
+    print(f"ci_timed_out: {ci_status.timed_out}")
+    print(f"ci_checks: {rendered_checks}")
+
+    if not decision.can_merge:
+        reason = "Shinobi stopped auto-merge because " + "; ".join(decision.reasons) + "."
+        finalize_mission(
+            root=root,
+            store=store,
+            config=config,
+            run_id=run_id,
+            state=build_review_state(
+                state=review_state,
+                config=config,
+                run_id=run_id,
+                phase="review",
+                review_loop_count=state.review_loop_count,
+                lease_expires_at=lease_expires_at,
+                last_result="needs-human",
+                last_error=reason,
+                ci_status=ci_status,
+            ),
+            conclusion="needs-human",
+            reason=reason,
+        )
+        print("merge_result: needs-human")
+        print(reason)
+        return 1
+
+    merge_pull_request(client=client, pr_number=pr_number, config=config)
+    finalize_mission(
+        root=root,
+        store=store,
+        config=config,
+        run_id=run_id,
+        state=review_state,
+        conclusion="merged",
+    )
+    print(f"merge_result: merged ({config.merge_method})")
+    return 0
 
 
 def handle_failed_ci_review(
@@ -835,15 +942,18 @@ def build_review_state(
     ci_status: Any,
     execution_result: ExecutionResult | None = None,
     retry_run_ids: list[str] | None = None,
+    extra: dict[str, Any] | None = None,
 ) -> State:
-    extra: dict[str, Any] = {
+    merged_extra: dict[str, Any] = {
         **state.extra,
         "ci_status": serialize_ci_status(ci_status),
     }
     if execution_result is not None:
-        extra["retry_verification"] = serialize_execution_result(execution_result)
+        merged_extra["retry_verification"] = serialize_execution_result(execution_result)
     if retry_run_ids is not None:
-        extra["retry_workflow_run_ids"] = retry_run_ids
+        merged_extra["retry_workflow_run_ids"] = retry_run_ids
+    if extra is not None:
+        merged_extra.update(extra)
 
     return State(
         issue_number=state.issue_number,
@@ -858,7 +968,7 @@ def build_review_state(
         last_result=last_result,
         last_error=last_error,
         last_mission=state.last_mission,
-        extra=extra,
+        extra=merged_extra,
     )
 
 

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -11,7 +11,13 @@ from typing import Any, Callable, List, Optional
 from urllib.parse import urlparse
 
 from .config import discover_workspace_root
-from .executor import detect_high_risk_stop, execute_verification
+from .executor import (
+    collect_paths_against_base_ref,
+    detect_high_risk_stop,
+    execute_verification,
+    find_high_risk_paths,
+    path_matches_high_risk,
+)
 from .github_client import GitHubClient, GitHubClientError
 from .issue_selector import (
     ensure_open_issue,
@@ -649,9 +655,17 @@ def handle_successful_ci_review(
         raise ReviewerError(f"failed to load issue #{issue_number} before merge: {error}") from error
 
     pull_request = load_review_pull_request(client=client, pr_number=pr_number)
-    diff_stats = collect_diff_stats(
-        root,
-        base_ref=resolve_review_base_ref(pull_request=pull_request, config=config),
+    base_ref = resolve_review_base_ref(pull_request=pull_request, config=config)
+    diff_stats = collect_diff_stats(root, base_ref=base_ref)
+    changed_paths = collect_paths_against_base_ref(root, base_ref=base_ref)
+    high_risk_paths = find_high_risk_paths(
+        changed_paths=changed_paths,
+        high_risk_paths=config.high_risk_paths,
+    )
+    high_risk_changed_paths = sorted(
+        path
+        for path in changed_paths
+        if any(path_matches_high_risk(path, high_risk_path) for high_risk_path in high_risk_paths)
     )
     decision = evaluate_merge(
         config=config,
@@ -659,6 +673,8 @@ def handle_successful_ci_review(
         issue=issue,
         ci_status=ci_status,
         diff_stats=diff_stats,
+        high_risk_paths=high_risk_paths,
+        high_risk_changed_paths=high_risk_changed_paths,
     )
     review_state = build_review_state(
         state=state,

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -697,7 +697,33 @@ def handle_successful_ci_review(
         print(reason)
         return 1
 
-    merge_pull_request(client=client, pr_number=pr_number, config=config)
+    try:
+        merge_pull_request(client=client, pr_number=pr_number, config=config)
+    except MergerError as error:
+        reason = f"Shinobi stopped auto-merge because {error}."
+        finalize_mission(
+            root=root,
+            store=store,
+            config=config,
+            run_id=run_id,
+            state=build_review_state(
+                state=review_state,
+                config=config,
+                run_id=run_id,
+                phase="review",
+                review_loop_count=state.review_loop_count,
+                lease_expires_at=lease_expires_at,
+                last_result="needs-human",
+                last_error=reason,
+                ci_status=ci_status,
+            ),
+            conclusion="needs-human",
+            reason=reason,
+        )
+        print("merge_result: needs-human")
+        print(reason)
+        return 1
+
     finalize_mission(
         root=root,
         store=store,

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -37,7 +37,7 @@ from .mission_start import (
     start_mission,
 )
 from .merger import MergerError, evaluate_merge, merge_pull_request
-from .models import Config, ExecutionResult, State, StopDecision
+from .models import Config, ExecutionResult, MissionSummary, State, StopDecision
 from .reviewer import ReviewerError, collect_diff_stats, wait_for_ci
 from .state_store import StateStore
 
@@ -736,14 +736,27 @@ def handle_successful_ci_review(
         print(reason)
         return 1
 
-    finalize_mission(
-        root=root,
-        store=store,
-        config=config,
-        run_id=run_id,
-        state=review_state,
-        conclusion="merged",
-    )
+    try:
+        finalize_mission(
+            root=root,
+            store=store,
+            config=config,
+            run_id=run_id,
+            state=review_state,
+            conclusion="merged",
+        )
+    except MissionFinalizeError as error:
+        warning = f"merged PR but finalize follow-up failed: {error}"
+        persist_merged_review_state(
+            store=store,
+            config=config,
+            state=review_state,
+            warning=warning,
+        )
+        print(f"merge_result: merged ({config.merge_method})")
+        print(f"merge_warning: {warning}")
+        return 1
+
     print(f"merge_result: merged ({config.merge_method})")
     return 0
 
@@ -989,6 +1002,43 @@ def load_current_branch(root: Path) -> str:
     if branch == "HEAD":
         raise RuntimeError("current git checkout is detached; review requires the mission branch")
     return branch
+
+
+def persist_merged_review_state(
+    *,
+    store: StateStore,
+    config: Config,
+    state: State,
+    warning: str,
+) -> None:
+    mission = state.last_mission or MissionSummary(
+        issue_number=state.issue_number,
+        pr_number=state.pr_number,
+        branch=state.branch,
+    )
+    store.save_state(
+        State(
+            issue_number=None,
+            pr_number=None,
+            branch=None,
+            agent_identity=config.agent_identity,
+            run_id=None,
+            phase="idle",
+            review_loop_count=0,
+            retryable_local_only=False,
+            lease_expires_at=None,
+            last_result="merged",
+            last_error=warning,
+            last_mission=MissionSummary(
+                issue_number=mission.issue_number,
+                pr_number=mission.pr_number,
+                branch=mission.branch,
+                phase="finalize",
+                conclusion="merged",
+            ),
+            extra=state.extra,
+        )
+    )
 
 
 def build_review_state(

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -647,7 +647,11 @@ def handle_successful_ci_review(
     except GitHubClientError as error:
         raise ReviewerError(f"failed to load issue #{issue_number} before merge: {error}") from error
 
-    diff_stats = collect_diff_stats(root, base_ref=config.main_branch)
+    pull_request = load_review_pull_request(client=client, pr_number=pr_number)
+    diff_stats = collect_diff_stats(
+        root,
+        base_ref=resolve_review_base_ref(pull_request=pull_request, config=config),
+    )
     decision = evaluate_merge(
         config=config,
         state=state,
@@ -710,7 +714,12 @@ def handle_successful_ci_review(
         return 1
 
     try:
-        merge_pull_request(client=client, pr_number=pr_number, config=config)
+        merge_pull_request(
+            client=client,
+            pr_number=pr_number,
+            config=config,
+            pull_request=pull_request,
+        )
     except MergerError as error:
         reason = f"Shinobi stopped auto-merge because {error}."
         finalize_mission(
@@ -759,6 +768,26 @@ def handle_successful_ci_review(
 
     print(f"merge_result: merged ({config.merge_method})")
     return 0
+
+
+def load_review_pull_request(
+    *,
+    client: GitHubClient,
+    pr_number: int,
+) -> dict[str, Any]:
+    try:
+        return client.get_pull_request(str(pr_number))
+    except GitHubClientError as error:
+        raise ReviewerError(f"failed to load PR #{pr_number} before merge: {error}") from error
+
+
+def resolve_review_base_ref(
+    *,
+    pull_request: dict[str, Any],
+    config: Config,
+) -> str:
+    base_ref = pull_request.get("baseRefName")
+    return base_ref if isinstance(base_ref, str) and base_ref.strip() else config.main_branch
 
 
 def handle_failed_ci_review(

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -655,6 +655,11 @@ def handle_successful_ci_review(
         raise ReviewerError(f"failed to load issue #{issue_number} before merge: {error}") from error
 
     pull_request = load_review_pull_request(client=client, pr_number=pr_number)
+    validate_review_pull_request_branch(
+        pull_request=pull_request,
+        state=state,
+        pr_number=pr_number,
+    )
     base_ref = resolve_review_base_ref(pull_request=pull_request, config=config)
     diff_stats = collect_diff_stats(root, base_ref=base_ref)
     changed_paths = collect_paths_against_base_ref(root, base_ref=base_ref)
@@ -805,6 +810,22 @@ def resolve_review_base_ref(
 ) -> str:
     base_ref = pull_request.get("baseRefName")
     return base_ref if isinstance(base_ref, str) and base_ref.strip() else config.main_branch
+
+
+def validate_review_pull_request_branch(
+    *,
+    pull_request: dict[str, Any],
+    state: State,
+    pr_number: int,
+) -> None:
+    branch = require_review_branch(state)
+    head_ref = pull_request.get("headRefName")
+    if not isinstance(head_ref, str) or not head_ref.strip():
+        raise ReviewerError(f"failed to validate PR #{pr_number} head branch before merge")
+    if head_ref != branch:
+        raise ReviewerError(
+            f"PR #{pr_number} head branch {head_ref} does not match mission branch {branch}"
+        )
 
 
 def handle_failed_ci_review(

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -702,10 +702,10 @@ def handle_successful_ci_review(
                 last_error=reason,
                 ci_status=ci_status,
             ),
-            conclusion="needs-human",
+            conclusion=decision.conclusion,
             reason=reason,
         )
-        print("merge_result: needs-human")
+        print(f"merge_result: {decision.conclusion}")
         print(reason)
         return 1
 

--- a/src/shinobi/merger.py
+++ b/src/shinobi/merger.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .github_client import GitHubClient, GitHubClientError
+from .models import CIStatus, Config, DiffStats, State
+from .reviewer import issue_label_names
+
+
+class MergerError(RuntimeError):
+    """Raised when merge inputs or operations are unsafe."""
+
+
+@dataclass(frozen=True)
+class MergeDecision:
+    should_merge: bool
+    reasons: list[str]
+
+    @property
+    def can_merge(self) -> bool:
+        return self.should_merge
+
+
+def evaluate_merge(
+    *,
+    config: Config,
+    state: State,
+    issue: dict[str, Any],
+    ci_status: CIStatus,
+    diff_stats: DiffStats,
+) -> MergeDecision:
+    reasons: list[str] = []
+    label_names = issue_label_names(issue)
+    risky_label = config.labels["risky"]
+
+    if not config.auto_merge:
+        reasons.append("auto_merge is disabled in config")
+
+    if ci_status.timed_out:
+        reasons.append("CI polling timed out before checks completed")
+    elif not ci_status.is_successful:
+        reasons.append(f"CI status is {ci_status.status}, not success")
+
+    if risky_label in label_names:
+        reasons.append(
+            f"issue #{issue['number']} has label {risky_label}, requiring human merge"
+        )
+
+    if state.review_loop_count >= config.max_review_loops:
+        reasons.append(
+            "review loop count "
+            f"{state.review_loop_count} reached max_review_loops {config.max_review_loops}"
+        )
+
+    if diff_stats.changed_files > config.max_changed_files:
+        reasons.append(
+            "changed files "
+            f"{diff_stats.changed_files} exceed max_changed_files {config.max_changed_files}"
+        )
+
+    if diff_stats.total_changed_lines > config.max_lines_changed:
+        reasons.append(
+            "total changed lines "
+            f"{diff_stats.total_changed_lines} exceed max_lines_changed {config.max_lines_changed}"
+        )
+
+    return MergeDecision(should_merge=not reasons, reasons=reasons)
+
+
+def merge_pull_request(
+    *,
+    client: GitHubClient,
+    pr_number: int,
+    config: Config,
+) -> None:
+    try:
+        client.merge_pull_request(
+            pr_number,
+            merge_method=config.merge_method,
+            delete_branch=True,
+        )
+    except GitHubClientError as error:
+        raise MergerError(f"failed to merge PR #{pr_number}: {error}") from error

--- a/src/shinobi/merger.py
+++ b/src/shinobi/merger.py
@@ -75,6 +75,9 @@ def merge_pull_request(
     config: Config,
 ) -> None:
     try:
+        pull_request = client.get_pull_request(str(pr_number))
+        if pull_request.get("isDraft"):
+            client.convert_pull_request_to_ready(pr_number)
         client.merge_pull_request(
             pr_number,
             merge_method=config.merge_method,

--- a/src/shinobi/merger.py
+++ b/src/shinobi/merger.py
@@ -85,10 +85,11 @@ def merge_pull_request(
     client: GitHubClient,
     pr_number: int,
     config: Config,
+    pull_request: dict[str, Any] | None = None,
 ) -> None:
     try:
-        pull_request = client.get_pull_request(str(pr_number))
-        if pull_request.get("isDraft"):
+        pull_request_payload = pull_request or client.get_pull_request(str(pr_number))
+        if pull_request_payload.get("isDraft"):
             client.convert_pull_request_to_ready(pr_number)
         client.merge_pull_request(
             pr_number,

--- a/src/shinobi/merger.py
+++ b/src/shinobi/merger.py
@@ -47,12 +47,6 @@ def evaluate_merge(
             f"issue #{issue['number']} has label {risky_label}, requiring human merge"
         )
 
-    if state.review_loop_count >= config.max_review_loops:
-        reasons.append(
-            "review loop count "
-            f"{state.review_loop_count} reached max_review_loops {config.max_review_loops}"
-        )
-
     if diff_stats.changed_files > config.max_changed_files:
         reasons.append(
             "changed files "

--- a/src/shinobi/merger.py
+++ b/src/shinobi/merger.py
@@ -32,6 +32,8 @@ def evaluate_merge(
     issue: dict[str, Any],
     ci_status: CIStatus,
     diff_stats: DiffStats,
+    high_risk_paths: list[str] | None = None,
+    high_risk_changed_paths: list[str] | None = None,
 ) -> MergeDecision:
     reasons: list[str] = []
     label_names = issue_label_names(issue)
@@ -66,6 +68,14 @@ def evaluate_merge(
         reasons.append(
             "total changed lines "
             f"{diff_stats.total_changed_lines} exceed max_lines_changed {config.max_lines_changed}"
+        )
+
+    if high_risk_paths:
+        joined_paths = ", ".join(high_risk_paths)
+        joined_files = ", ".join(high_risk_changed_paths or [])
+        reasons.append(
+            "changed files match high-risk path(s): "
+            f"{joined_paths} (files: {joined_files})"
         )
 
     if state.review_loop_count >= config.max_review_loops:

--- a/src/shinobi/merger.py
+++ b/src/shinobi/merger.py
@@ -7,6 +7,8 @@ from .github_client import GitHubClient, GitHubClientError
 from .models import CIStatus, Config, DiffStats, State
 from .reviewer import issue_label_names
 
+BLOCKING_MERGE_LABEL_KEYS = ("blocked", "needs_human")
+
 
 class MergerError(RuntimeError):
     """Raised when merge inputs or operations are unsafe."""
@@ -16,6 +18,7 @@ class MergerError(RuntimeError):
 class MergeDecision:
     should_merge: bool
     reasons: list[str]
+    conclusion: str = "needs-human"
 
     @property
     def can_merge(self) -> bool:
@@ -33,6 +36,7 @@ def evaluate_merge(
     reasons: list[str] = []
     label_names = issue_label_names(issue)
     risky_label = config.labels["risky"]
+    blocking_labels = find_blocking_merge_labels(label_names=label_names, config=config)
 
     if not config.auto_merge:
         reasons.append("auto_merge is disabled in config")
@@ -47,6 +51,11 @@ def evaluate_merge(
             f"issue #{issue['number']} has label {risky_label}, requiring human merge"
         )
 
+    if blocking_labels:
+        reasons.append(
+            f"issue #{issue['number']} has blocking label(s): {', '.join(blocking_labels)}"
+        )
+
     if diff_stats.changed_files > config.max_changed_files:
         reasons.append(
             "changed files "
@@ -59,7 +68,16 @@ def evaluate_merge(
             f"{diff_stats.total_changed_lines} exceed max_lines_changed {config.max_lines_changed}"
         )
 
-    return MergeDecision(should_merge=not reasons, reasons=reasons)
+    conclusion = "blocked" if config.labels["blocked"] in blocking_labels else "needs-human"
+    return MergeDecision(should_merge=not reasons, reasons=reasons, conclusion=conclusion)
+
+
+def find_blocking_merge_labels(*, label_names: set[str], config: Config) -> list[str]:
+    return sorted(
+        config.labels[key]
+        for key in BLOCKING_MERGE_LABEL_KEYS
+        if key in config.labels and config.labels[key] in label_names
+    )
 
 
 def merge_pull_request(

--- a/src/shinobi/reviewer.py
+++ b/src/shinobi/reviewer.py
@@ -36,6 +36,31 @@ FAILURE_CHECK_STATES = {
 
 
 def collect_diff_stats(root: Path, *, base_ref: str) -> DiffStats:
+    errors: list[str] = []
+    for candidate_ref in diff_base_ref_candidates(base_ref):
+        try:
+            return collect_diff_stats_against_ref(root, base_ref=candidate_ref)
+        except ReviewerError as error:
+            error_message = str(error)
+            errors.append(error_message)
+            if not is_missing_revision_error(error_message):
+                break
+
+    joined_errors = "; ".join(errors)
+    raise ReviewerError(joined_errors)
+
+
+def diff_base_ref_candidates(base_ref: str) -> list[str]:
+    if base_ref.startswith("origin/"):
+        return [base_ref]
+
+    remote_candidate = f"origin/{base_ref}"
+    if remote_candidate == base_ref:
+        return [base_ref]
+    return [remote_candidate, base_ref]
+
+
+def collect_diff_stats_against_ref(root: Path, *, base_ref: str) -> DiffStats:
     try:
         result = subprocess.run(
             ["git", "diff", "--numstat", f"{base_ref}...HEAD"],
@@ -52,6 +77,11 @@ def collect_diff_stats(root: Path, *, base_ref: str) -> DiffStats:
         raise ReviewerError(f"failed to collect diff stats against {base_ref}: {message}")
 
     return parse_numstat(result.stdout)
+
+
+def is_missing_revision_error(message: str) -> bool:
+    lowered = message.lower()
+    return "unknown revision" in lowered or "bad revision" in lowered
 
 
 def parse_numstat(output: str) -> DiffStats:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -836,6 +836,107 @@ class CliTest(unittest.TestCase):
             self.assertEqual(saved_state.last_mission.conclusion, "needs-human")
             self.assertIsNone(store.load_lock())
 
+    def test_review_persists_merged_state_when_finalize_fails_after_merge(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            issue_number=33,
+                            pr_number=44,
+                            branch="feature/issue-33-review-ci",
+                            agent_identity=config.agent_identity,
+                            run_id="publish-run",
+                            phase="review",
+                            last_result="review-retry",
+                        )
+                    )
+
+                    output = io.StringIO()
+                    client = Mock()
+                    client.list_issue_comments.return_value = [
+                        {
+                            "id": 9001,
+                            "body": (
+                                "<!-- shinobi:mission-state\n"
+                                "issue: 33\n"
+                                "branch: feature/issue-33-review-ci\n"
+                                "phase: review\n"
+                                "pr: 44\n"
+                                "-->\n"
+                            ),
+                        }
+                    ]
+                    client.get_issue.return_value = {
+                        "number": 33,
+                        "state": "OPEN",
+                        "labels": [{"name": config.labels["reviewing"]}],
+                    }
+                    client.get_pull_request.return_value = {
+                        "number": 44,
+                        "isDraft": False,
+                    }
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
+                        with patch(
+                            "shinobi.cli.collect_diff_stats",
+                            return_value=DiffStats(
+                                changed_files=2,
+                                added_lines=10,
+                                deleted_lines=3,
+                            ),
+                        ):
+                            with patch(
+                                "shinobi.cli.wait_for_ci",
+                                return_value=CIStatus(
+                                    checks=[
+                                        PullRequestCheck(
+                                            name="test",
+                                            state="SUCCESS",
+                                            bucket="pass",
+                                        )
+                                    ],
+                                    status="success",
+                                ),
+                            ):
+                                with patch(
+                                    "shinobi.cli.load_current_branch",
+                                    return_value="feature/issue-33-review-ci",
+                                ):
+                                    with patch(
+                                        "shinobi.cli.finalize_mission",
+                                        side_effect=MissionFinalizeError(
+                                            "failed to create finalize comment on issue #33: api unavailable"
+                                        ),
+                                    ):
+                                        with redirect_stdout(output):
+                                            exit_code = cli.main(["review"])
+
+            self.assertEqual(exit_code, 1)
+            rendered = output.getvalue()
+            self.assertIn("merge_result: merged (squash)", rendered)
+            self.assertIn("merge_warning: merged PR but finalize follow-up failed", rendered)
+            client.merge_pull_request.assert_called_once_with(
+                44,
+                merge_method=config.merge_method,
+                delete_branch=True,
+            )
+
+            saved_state = store.load_state()
+            self.assertEqual(saved_state.phase, "idle")
+            self.assertEqual(saved_state.last_result, "merged")
+            self.assertIn("merged PR but finalize follow-up failed", saved_state.last_error)
+            self.assertEqual(saved_state.last_mission.issue_number, 33)
+            self.assertEqual(saved_state.last_mission.pr_number, 44)
+            self.assertEqual(saved_state.last_mission.conclusion, "merged")
+            self.assertIsNone(store.load_lock())
+
     def test_review_timeout_returns_nonzero_and_persists_pending_result(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -725,6 +725,95 @@ class CliTest(unittest.TestCase):
             self.assertEqual(saved_state.last_mission.conclusion, "needs-human")
             self.assertIsNone(store.load_lock())
 
+    def test_review_successful_ci_finalizes_needs_human_when_merge_command_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            issue_number=33,
+                            pr_number=44,
+                            branch="feature/issue-33-review-ci",
+                            agent_identity=config.agent_identity,
+                            run_id="publish-run",
+                            phase="review",
+                            last_result="review-retry",
+                        )
+                    )
+
+                    output = io.StringIO()
+                    client = Mock()
+                    client.list_issue_comments.return_value = [
+                        {
+                            "id": 9001,
+                            "body": (
+                                "<!-- shinobi:mission-state\n"
+                                "issue: 33\n"
+                                "branch: feature/issue-33-review-ci\n"
+                                "phase: review\n"
+                                "pr: 44\n"
+                                "-->\n"
+                            ),
+                        }
+                    ]
+                    client.get_issue.return_value = {
+                        "number": 33,
+                        "state": "OPEN",
+                        "labels": [{"name": config.labels["reviewing"]}],
+                    }
+                    client.merge_pull_request.side_effect = GitHubClientError(
+                        "merge blocked by branch protection"
+                    )
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
+                        with patch("shinobi.mission_finalize.GitHubClient", return_value=client):
+                            with patch(
+                                "shinobi.cli.collect_diff_stats",
+                                return_value=DiffStats(
+                                    changed_files=2,
+                                    added_lines=10,
+                                    deleted_lines=3,
+                                ),
+                            ):
+                                with patch(
+                                    "shinobi.cli.wait_for_ci",
+                                    return_value=CIStatus(
+                                        checks=[
+                                            PullRequestCheck(
+                                                name="test",
+                                                state="SUCCESS",
+                                                bucket="pass",
+                                            )
+                                        ],
+                                        status="success",
+                                    ),
+                                ):
+                                    with redirect_stdout(output):
+                                        exit_code = cli.main(["review"])
+
+            self.assertEqual(exit_code, 1)
+            rendered = output.getvalue()
+            self.assertIn("merge_result: needs-human", rendered)
+            self.assertIn("failed to merge PR #44", rendered)
+            self.assertIn("branch protection", rendered)
+            client.update_issue_labels.assert_any_call(33, add=[config.labels["needs_human"]])
+            client.update_issue_labels.assert_any_call(33, remove=[config.labels["reviewing"]])
+            client.close_issue.assert_not_called()
+
+            saved_state = store.load_state()
+            self.assertEqual(saved_state.phase, "idle")
+            self.assertEqual(saved_state.last_result, "needs-human")
+            self.assertEqual(saved_state.last_mission.issue_number, 33)
+            self.assertEqual(saved_state.last_mission.pr_number, 44)
+            self.assertEqual(saved_state.last_mission.conclusion, "needs-human")
+            self.assertIsNone(store.load_lock())
+
     def test_review_timeout_returns_nonzero_and_persists_pending_result(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -574,6 +574,7 @@ class CliTest(unittest.TestCase):
                     client.get_pull_request.return_value = {
                         "number": 44,
                         "isDraft": True,
+                        "baseRefName": "release/1.0",
                     }
                     client.convert_pull_request_to_ready.return_value = {
                         "number": 44,
@@ -588,7 +589,7 @@ class CliTest(unittest.TestCase):
                                     added_lines=10,
                                     deleted_lines=3,
                                 ),
-                            ):
+                            ) as collect_diff_stats_mock:
                                 with patch(
                                     "shinobi.cli.wait_for_ci",
                                     return_value=CIStatus(
@@ -630,6 +631,7 @@ class CliTest(unittest.TestCase):
             self.assertEqual(wait_for_ci_mock.call_args.kwargs["timeout_seconds"], 30.0)
             self.assertEqual(wait_for_ci_mock.call_args.kwargs["poll_interval_seconds"], 5.0)
             self.assertIsNotNone(wait_for_ci_mock.call_args.kwargs["heartbeat"])
+            collect_diff_stats_mock.assert_called_once_with(root, base_ref="release/1.0")
             self.assertEqual(client.update_issue_comment.call_count, 2)
             self.assertIn("phase: review", client.update_issue_comment.call_args_list[0].args[1])
             self.assertIn("pr: 44", client.update_issue_comment.call_args_list[0].args[1])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -602,16 +602,20 @@ class CliTest(unittest.TestCase):
                                         status="success",
                                     ),
                                 ) as wait_for_ci_mock:
-                                    with redirect_stdout(output):
-                                        exit_code = cli.main(
-                                            [
-                                                "review",
-                                                "--timeout-seconds",
-                                                "30",
-                                                "--poll-interval-seconds",
-                                                "5",
-                                            ]
-                                        )
+                                    with patch(
+                                        "shinobi.cli.load_current_branch",
+                                        return_value="feature/issue-33-review-ci",
+                                    ):
+                                        with redirect_stdout(output):
+                                            exit_code = cli.main(
+                                                [
+                                                    "review",
+                                                    "--timeout-seconds",
+                                                    "30",
+                                                    "--poll-interval-seconds",
+                                                    "5",
+                                                ]
+                                            )
 
             self.assertEqual(exit_code, 0)
             rendered = output.getvalue()
@@ -717,8 +721,12 @@ class CliTest(unittest.TestCase):
                                         status="success",
                                     ),
                                 ):
-                                    with redirect_stdout(output):
-                                        exit_code = cli.main(["review"])
+                                    with patch(
+                                        "shinobi.cli.load_current_branch",
+                                        return_value="feature/issue-33-review-ci",
+                                    ):
+                                        with redirect_stdout(output):
+                                            exit_code = cli.main(["review"])
 
             self.assertEqual(exit_code, 1)
             rendered = output.getvalue()
@@ -804,8 +812,12 @@ class CliTest(unittest.TestCase):
                                         status="success",
                                     ),
                                 ):
-                                    with redirect_stdout(output):
-                                        exit_code = cli.main(["review"])
+                                    with patch(
+                                        "shinobi.cli.load_current_branch",
+                                        return_value="feature/issue-33-review-ci",
+                                    ):
+                                        with redirect_stdout(output):
+                                            exit_code = cli.main(["review"])
 
             self.assertEqual(exit_code, 1)
             rendered = output.getvalue()
@@ -877,8 +889,12 @@ class CliTest(unittest.TestCase):
                                 timed_out=True,
                             ),
                         ):
-                            with redirect_stdout(output):
-                                exit_code = cli.main(["review"])
+                            with patch(
+                                "shinobi.cli.load_current_branch",
+                                return_value="feature/issue-33-review-ci",
+                            ):
+                                with redirect_stdout(output):
+                                    exit_code = cli.main(["review"])
 
             self.assertEqual(exit_code, 1)
             rendered = output.getvalue()
@@ -966,8 +982,12 @@ class CliTest(unittest.TestCase):
                                     "shinobi.cli.wait_for_ci",
                                     side_effect=wait_for_ci_side_effect,
                                 ):
-                                    with redirect_stdout(io.StringIO()):
-                                        exit_code = cli.main(["review"])
+                                    with patch(
+                                        "shinobi.cli.load_current_branch",
+                                        return_value="feature/issue-33-review-ci",
+                                    ):
+                                        with redirect_stdout(io.StringIO()):
+                                            exit_code = cli.main(["review"])
 
             self.assertEqual(exit_code, 0)
             self.assertEqual(client.update_issue_comment.call_count, 3)
@@ -1044,8 +1064,12 @@ class CliTest(unittest.TestCase):
                                 "shinobi.cli.execute_verification",
                                 return_value=execution_result,
                             ) as execute_verification_mock:
-                                with redirect_stdout(output):
-                                    exit_code = cli.main(["review"])
+                                with patch(
+                                    "shinobi.cli.load_current_branch",
+                                    return_value="feature/issue-33-review-ci",
+                                ):
+                                    with redirect_stdout(output):
+                                        exit_code = cli.main(["review"])
 
             self.assertEqual(exit_code, 1)
             rendered = output.getvalue()
@@ -1131,8 +1155,12 @@ class CliTest(unittest.TestCase):
                                     status="failure",
                                 ),
                             ):
-                                with redirect_stdout(output):
-                                    exit_code = cli.main(["review"])
+                                with patch(
+                                    "shinobi.cli.load_current_branch",
+                                    return_value="feature/issue-33-review-ci",
+                                ):
+                                    with redirect_stdout(output):
+                                        exit_code = cli.main(["review"])
 
             self.assertEqual(exit_code, 1)
             rendered = output.getvalue()
@@ -1321,8 +1349,12 @@ class CliTest(unittest.TestCase):
                                     "shinobi.cli.execute_verification",
                                     return_value=execution_result,
                                 ) as execute_verification_mock:
-                                    with redirect_stdout(output):
-                                        exit_code = cli.main(["review"])
+                                    with patch(
+                                        "shinobi.cli.load_current_branch",
+                                        return_value="feature/issue-33-review-ci",
+                                    ):
+                                        with redirect_stdout(output):
+                                            exit_code = cli.main(["review"])
 
             self.assertEqual(exit_code, 1)
             rendered = output.getvalue()
@@ -1390,8 +1422,12 @@ class CliTest(unittest.TestCase):
                             "shinobi.cli.wait_for_ci",
                             side_effect=ReviewerError("api unavailable"),
                         ):
-                            with redirect_stdout(output):
-                                exit_code = cli.main(["review"])
+                            with patch(
+                                "shinobi.cli.load_current_branch",
+                                return_value="feature/issue-33-review-ci",
+                            ):
+                                with redirect_stdout(output):
+                                    exit_code = cli.main(["review"])
 
             self.assertEqual(exit_code, 1)
             self.assertIn("review aborted: api unavailable", output.getvalue())
@@ -1459,8 +1495,12 @@ class CliTest(unittest.TestCase):
                                 status="success",
                             ),
                         ):
-                            with redirect_stdout(output):
-                                exit_code = cli.main(["review"])
+                            with patch(
+                                "shinobi.cli.load_current_branch",
+                                return_value="feature/issue-33-review-ci",
+                            ):
+                                with redirect_stdout(output):
+                                    exit_code = cli.main(["review"])
 
             self.assertEqual(exit_code, 1)
             self.assertIn(
@@ -1547,6 +1587,47 @@ class CliTest(unittest.TestCase):
                 output.getvalue(),
             )
             client.assert_not_called()
+            self.assertIsNone(store.load_lock())
+
+    def test_review_aborts_when_current_branch_does_not_match_mission_branch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            issue_number=33,
+                            pr_number=44,
+                            branch="feature/issue-33-review-ci",
+                            agent_identity=config.agent_identity,
+                            run_id="publish-run",
+                            phase="publish",
+                            last_result="published",
+                        )
+                    )
+
+                    output = io.StringIO()
+                    client = Mock()
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
+                        with patch("shinobi.cli.load_current_branch", return_value="main"):
+                            with redirect_stdout(output):
+                                exit_code = cli.main(["review"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn(
+                "review aborted: current git branch main does not match mission branch "
+                "feature/issue-33-review-ci",
+                output.getvalue(),
+            )
+            client.assert_not_called()
+            self.assertEqual(store.load_state().phase, "publish")
+            self.assertEqual(store.load_state().last_result, "published")
             self.assertIsNone(store.load_lock())
 
     def test_review_rejects_invalid_poll_interval_before_side_effects(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,7 +28,7 @@ from shinobi.executor import (
     run_verification_command,
 )
 from shinobi.github_client import GitHubClient, GitHubClientError
-from shinobi.merger import MergeDecision, evaluate_merge
+from shinobi.merger import MergeDecision, MergerError, evaluate_merge, merge_pull_request
 from shinobi.mission_finalize import (
     MissionFinalizeError,
     finalize_mission,
@@ -571,6 +571,14 @@ class CliTest(unittest.TestCase):
                         "state": "OPEN",
                         "labels": [{"name": config.labels["reviewing"]}],
                     }
+                    client.get_pull_request.return_value = {
+                        "number": 44,
+                        "isDraft": True,
+                    }
+                    client.convert_pull_request_to_ready.return_value = {
+                        "number": 44,
+                        "isDraft": False,
+                    }
                     with patch("shinobi.cli.GitHubClient", return_value=client):
                         with patch("shinobi.mission_finalize.GitHubClient", return_value=client):
                             with patch(
@@ -621,6 +629,8 @@ class CliTest(unittest.TestCase):
             self.assertEqual(client.update_issue_comment.call_count, 2)
             self.assertIn("phase: review", client.update_issue_comment.call_args_list[0].args[1])
             self.assertIn("pr: 44", client.update_issue_comment.call_args_list[0].args[1])
+            client.get_pull_request.assert_called_once_with("44")
+            client.convert_pull_request_to_ready.assert_called_once_with(44)
             client.merge_pull_request.assert_called_once_with(
                 44,
                 merge_method=config.merge_method,
@@ -6948,6 +6958,47 @@ class ReviewerTest(unittest.TestCase):
                 ],
             ),
         )
+
+    def test_merge_pull_request_marks_draft_pr_ready_before_merging(self) -> None:
+        client = Mock()
+        config = Config(repo="owner/repo", merge_method="squash")
+        client.get_pull_request.return_value = {
+            "number": 44,
+            "isDraft": True,
+        }
+        client.convert_pull_request_to_ready.return_value = {
+            "number": 44,
+            "isDraft": False,
+        }
+
+        merge_pull_request(client=client, pr_number=44, config=config)
+
+        client.get_pull_request.assert_called_once_with("44")
+        client.convert_pull_request_to_ready.assert_called_once_with(44)
+        client.merge_pull_request.assert_called_once_with(
+            44,
+            merge_method="squash",
+            delete_branch=True,
+        )
+
+    def test_merge_pull_request_wraps_ready_transition_failure(self) -> None:
+        client = Mock()
+        config = Config(repo="owner/repo", merge_method="squash")
+        client.get_pull_request.return_value = {
+            "number": 44,
+            "isDraft": True,
+        }
+        client.convert_pull_request_to_ready.side_effect = GitHubClientError(
+            "draft pull requests cannot be merged"
+        )
+
+        with self.assertRaisesRegex(
+            MergerError,
+            "failed to merge PR #44: draft pull requests cannot be merged",
+        ):
+            merge_pull_request(client=client, pr_number=44, config=config)
+
+        client.merge_pull_request.assert_not_called()
 
     def test_collect_ci_status_classifies_checks(self) -> None:
         client = Mock()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8089,6 +8089,61 @@ class ReviewerTest(unittest.TestCase):
         )
         self.assertEqual(stats.total_changed_lines, 15)
 
+    def test_collect_diff_stats_prefers_remote_base_ref(self) -> None:
+        with patch(
+            "shinobi.reviewer.subprocess.run",
+            return_value=Mock(
+                returncode=0,
+                stdout="12\t3\tsrc/shinobi/reviewer.py\n",
+                stderr="",
+            ),
+        ) as run_mock:
+            stats = collect_diff_stats(Path("/tmp/repo"), base_ref="release/1.0")
+
+        self.assertEqual(
+            stats,
+            DiffStats(
+                changed_files=1,
+                added_lines=12,
+                deleted_lines=3,
+            ),
+        )
+        run_mock.assert_called_once_with(
+            ["git", "diff", "--numstat", "origin/release/1.0...HEAD"],
+            cwd=Path("/tmp/repo"),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_collect_diff_stats_falls_back_to_local_base_ref(self) -> None:
+        with patch(
+            "shinobi.reviewer.subprocess.run",
+            side_effect=[
+                Mock(returncode=1, stdout="", stderr="unknown revision"),
+                Mock(returncode=0, stdout="4\t2\tsrc/shinobi/cli.py\n", stderr=""),
+            ],
+        ) as run_mock:
+            stats = collect_diff_stats(Path("/tmp/repo"), base_ref="release/1.0")
+
+        self.assertEqual(
+            stats,
+            DiffStats(
+                changed_files=1,
+                added_lines=4,
+                deleted_lines=2,
+            ),
+        )
+        self.assertEqual(run_mock.call_count, 2)
+        self.assertEqual(
+            run_mock.call_args_list[0].args[0],
+            ["git", "diff", "--numstat", "origin/release/1.0...HEAD"],
+        )
+        self.assertEqual(
+            run_mock.call_args_list[1].args[0],
+            ["git", "diff", "--numstat", "release/1.0...HEAD"],
+        )
+
     def test_collect_diff_stats_wraps_git_failures(self) -> None:
         with patch(
             "shinobi.reviewer.subprocess.run",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,6 +28,7 @@ from shinobi.executor import (
     run_verification_command,
 )
 from shinobi.github_client import GitHubClient, GitHubClientError
+from shinobi.merger import MergeDecision, evaluate_merge
 from shinobi.mission_finalize import (
     MissionFinalizeError,
     finalize_mission,
@@ -527,7 +528,7 @@ class CliTest(unittest.TestCase):
             self.assertFalse(store.paths.decisions_path.exists())
             self.assertFalse(store.paths.lock_path.exists())
 
-    def test_review_waits_for_ci_and_persists_review_state(self) -> None:
+    def test_review_waits_for_ci_merges_and_finalizes_when_auto_merge_is_safe(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)
             with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
@@ -565,30 +566,44 @@ class CliTest(unittest.TestCase):
                             ),
                         }
                     ]
+                    client.get_issue.return_value = {
+                        "number": 33,
+                        "state": "OPEN",
+                        "labels": [{"name": config.labels["reviewing"]}],
+                    }
                     with patch("shinobi.cli.GitHubClient", return_value=client):
-                        with patch(
-                            "shinobi.cli.wait_for_ci",
-                            return_value=CIStatus(
-                                checks=[
-                                    PullRequestCheck(
-                                        name="test",
-                                        state="SUCCESS",
-                                        bucket="pass",
-                                    )
-                                ],
-                                status="success",
-                            ),
-                        ) as wait_for_ci_mock:
-                            with redirect_stdout(output):
-                                exit_code = cli.main(
-                                    [
-                                        "review",
-                                        "--timeout-seconds",
-                                        "30",
-                                        "--poll-interval-seconds",
-                                        "5",
-                                    ]
-                                )
+                        with patch("shinobi.mission_finalize.GitHubClient", return_value=client):
+                            with patch(
+                                "shinobi.cli.collect_diff_stats",
+                                return_value=DiffStats(
+                                    changed_files=2,
+                                    added_lines=10,
+                                    deleted_lines=3,
+                                ),
+                            ):
+                                with patch(
+                                    "shinobi.cli.wait_for_ci",
+                                    return_value=CIStatus(
+                                        checks=[
+                                            PullRequestCheck(
+                                                name="test",
+                                                state="SUCCESS",
+                                                bucket="pass",
+                                            )
+                                        ],
+                                        status="success",
+                                    ),
+                                ) as wait_for_ci_mock:
+                                    with redirect_stdout(output):
+                                        exit_code = cli.main(
+                                            [
+                                                "review",
+                                                "--timeout-seconds",
+                                                "30",
+                                                "--poll-interval-seconds",
+                                                "5",
+                                            ]
+                                        )
 
             self.assertEqual(exit_code, 0)
             rendered = output.getvalue()
@@ -596,6 +611,7 @@ class CliTest(unittest.TestCase):
             self.assertIn("review_pr: #44", rendered)
             self.assertIn("ci_status: success", rendered)
             self.assertIn("ci_checks: test=pass", rendered)
+            self.assertIn("merge_result: merged (squash)", rendered)
             wait_for_ci_mock.assert_called_once()
             self.assertIs(wait_for_ci_mock.call_args.args[0], client)
             self.assertEqual(wait_for_ci_mock.call_args.args[1], 44)
@@ -605,15 +621,108 @@ class CliTest(unittest.TestCase):
             self.assertEqual(client.update_issue_comment.call_count, 2)
             self.assertIn("phase: review", client.update_issue_comment.call_args_list[0].args[1])
             self.assertIn("pr: 44", client.update_issue_comment.call_args_list[0].args[1])
+            client.merge_pull_request.assert_called_once_with(
+                44,
+                merge_method=config.merge_method,
+                delete_branch=True,
+            )
+            client.update_issue_labels.assert_any_call(33, add=[config.labels["merged"]])
+            client.update_issue_labels.assert_any_call(33, remove=[config.labels["reviewing"]])
+            client.close_issue.assert_called_once_with(33)
 
             saved_state = store.load_state()
-            self.assertEqual(saved_state.phase, "review")
-            self.assertEqual(saved_state.run_id, "publish-run")
-            self.assertEqual(saved_state.last_result, "ci-success")
-            self.assertIsNone(saved_state.last_error)
-            self.assertEqual(saved_state.extra["ci_status"]["status"], "success")
-            self.assertFalse(saved_state.extra["ci_status"]["timed_out"])
-            self.assertEqual(saved_state.extra["ci_status"]["checks"][0]["name"], "test")
+            self.assertEqual(saved_state.phase, "idle")
+            self.assertEqual(saved_state.last_result, "merged")
+            self.assertEqual(saved_state.last_mission.issue_number, 33)
+            self.assertEqual(saved_state.last_mission.pr_number, 44)
+            self.assertEqual(saved_state.last_mission.conclusion, "merged")
+            self.assertIsNone(store.load_lock())
+
+    def test_review_successful_ci_finalizes_needs_human_when_merge_is_ineligible(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            issue_number=33,
+                            pr_number=44,
+                            branch="feature/issue-33-review-ci",
+                            agent_identity=config.agent_identity,
+                            run_id="publish-run",
+                            phase="review",
+                            last_result="review-retry",
+                        )
+                    )
+
+                    output = io.StringIO()
+                    client = Mock()
+                    client.list_issue_comments.return_value = [
+                        {
+                            "id": 9001,
+                            "body": (
+                                "<!-- shinobi:mission-state\n"
+                                "issue: 33\n"
+                                "branch: feature/issue-33-review-ci\n"
+                                "phase: review\n"
+                                "pr: 44\n"
+                                "-->\n"
+                            ),
+                        }
+                    ]
+                    client.get_issue.return_value = {
+                        "number": 33,
+                        "state": "OPEN",
+                        "labels": [
+                            {"name": config.labels["reviewing"]},
+                            {"name": config.labels["risky"]},
+                        ],
+                    }
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
+                        with patch("shinobi.mission_finalize.GitHubClient", return_value=client):
+                            with patch(
+                                "shinobi.cli.collect_diff_stats",
+                                return_value=DiffStats(
+                                    changed_files=2,
+                                    added_lines=10,
+                                    deleted_lines=3,
+                                ),
+                            ):
+                                with patch(
+                                    "shinobi.cli.wait_for_ci",
+                                    return_value=CIStatus(
+                                        checks=[
+                                            PullRequestCheck(
+                                                name="test",
+                                                state="SUCCESS",
+                                                bucket="pass",
+                                            )
+                                        ],
+                                        status="success",
+                                    ),
+                                ):
+                                    with redirect_stdout(output):
+                                        exit_code = cli.main(["review"])
+
+            self.assertEqual(exit_code, 1)
+            rendered = output.getvalue()
+            self.assertIn("merge_result: needs-human", rendered)
+            self.assertIn("has label shinobi:risky", rendered)
+            client.merge_pull_request.assert_not_called()
+            client.update_issue_labels.assert_any_call(33, add=[config.labels["needs_human"]])
+            client.update_issue_labels.assert_any_call(33, remove=[config.labels["reviewing"]])
+
+            saved_state = store.load_state()
+            self.assertEqual(saved_state.phase, "idle")
+            self.assertEqual(saved_state.last_result, "needs-human")
+            self.assertEqual(saved_state.last_mission.issue_number, 33)
+            self.assertEqual(saved_state.last_mission.conclusion, "needs-human")
             self.assertIsNone(store.load_lock())
 
     def test_review_timeout_returns_nonzero_and_persists_pending_result(self) -> None:
@@ -722,6 +831,11 @@ class CliTest(unittest.TestCase):
                             ),
                         }
                     ]
+                    client.get_issue.return_value = {
+                        "number": 33,
+                        "state": "OPEN",
+                        "labels": [{"name": config.labels["reviewing"]}],
+                    }
 
                     def wait_for_ci_side_effect(*_args, **kwargs):
                         kwargs["heartbeat"]()
@@ -738,11 +852,23 @@ class CliTest(unittest.TestCase):
 
                     with patch("shinobi.cli.GitHubClient", return_value=client):
                         with patch(
-                            "shinobi.cli.wait_for_ci",
-                            side_effect=wait_for_ci_side_effect,
+                            "shinobi.mission_finalize.GitHubClient",
+                            return_value=client,
                         ):
-                            with redirect_stdout(io.StringIO()):
-                                exit_code = cli.main(["review"])
+                            with patch(
+                                "shinobi.cli.collect_diff_stats",
+                                return_value=DiffStats(
+                                    changed_files=2,
+                                    added_lines=10,
+                                    deleted_lines=3,
+                                ),
+                            ):
+                                with patch(
+                                    "shinobi.cli.wait_for_ci",
+                                    side_effect=wait_for_ci_side_effect,
+                                ):
+                                    with redirect_stdout(io.StringIO()):
+                                        exit_code = cli.main(["review"])
 
             self.assertEqual(exit_code, 0)
             self.assertEqual(client.update_issue_comment.call_count, 3)
@@ -6694,6 +6820,44 @@ class ReviewerTest(unittest.TestCase):
                 "total changed lines 27 exceed max_lines_changed 20",
                 "review loop count 2 reached max_review_loops 2",
             ],
+        )
+
+    def test_evaluate_merge_stops_for_ci_risk_and_size_limits(self) -> None:
+        config = Config(
+            repo="owner/repo",
+            auto_merge=False,
+            max_changed_files=4,
+            max_lines_changed=10,
+            max_review_loops=2,
+        )
+
+        decision = evaluate_merge(
+            config=config,
+            state=State(review_loop_count=2),
+            issue={
+                "number": 34,
+                "labels": [{"name": "shinobi:risky"}],
+            },
+            ci_status=CIStatus(
+                checks=[PullRequestCheck(name="test", state="FAILURE", bucket="fail")],
+                status="failure",
+            ),
+            diff_stats=DiffStats(changed_files=5, added_lines=7, deleted_lines=9),
+        )
+
+        self.assertEqual(
+            decision,
+            MergeDecision(
+                should_merge=False,
+                reasons=[
+                    "auto_merge is disabled in config",
+                    "CI status is failure, not success",
+                    "issue #34 has label shinobi:risky, requiring human merge",
+                    "review loop count 2 reached max_review_loops 2",
+                    "changed files 5 exceed max_changed_files 4",
+                    "total changed lines 16 exceed max_lines_changed 10",
+                ],
+            ),
         )
 
     def test_collect_ci_status_classifies_checks(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -743,6 +743,97 @@ class CliTest(unittest.TestCase):
             self.assertEqual(saved_state.last_mission.conclusion, "needs-human")
             self.assertIsNone(store.load_lock())
 
+    def test_review_successful_ci_preserves_blocked_handoff_when_issue_is_human_stopped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            issue_number=33,
+                            pr_number=44,
+                            branch="feature/issue-33-review-ci",
+                            agent_identity=config.agent_identity,
+                            run_id="publish-run",
+                            phase="review",
+                            last_result="review-retry",
+                        )
+                    )
+
+                    output = io.StringIO()
+                    client = Mock()
+                    client.list_issue_comments.return_value = [
+                        {
+                            "id": 9001,
+                            "body": (
+                                "<!-- shinobi:mission-state\n"
+                                "issue: 33\n"
+                                "branch: feature/issue-33-review-ci\n"
+                                "phase: review\n"
+                                "pr: 44\n"
+                                "-->\n"
+                            ),
+                        }
+                    ]
+                    client.get_issue.return_value = {
+                        "number": 33,
+                        "state": "OPEN",
+                        "labels": [
+                            {"name": config.labels["reviewing"]},
+                            {"name": config.labels["blocked"]},
+                        ],
+                    }
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
+                        with patch("shinobi.mission_finalize.GitHubClient", return_value=client):
+                            with patch(
+                                "shinobi.cli.collect_diff_stats",
+                                return_value=DiffStats(
+                                    changed_files=2,
+                                    added_lines=10,
+                                    deleted_lines=3,
+                                ),
+                            ):
+                                with patch(
+                                    "shinobi.cli.wait_for_ci",
+                                    return_value=CIStatus(
+                                        checks=[
+                                            PullRequestCheck(
+                                                name="test",
+                                                state="SUCCESS",
+                                                bucket="pass",
+                                            )
+                                        ],
+                                        status="success",
+                                    ),
+                                ):
+                                    with patch(
+                                        "shinobi.cli.load_current_branch",
+                                        return_value="feature/issue-33-review-ci",
+                                    ):
+                                        with redirect_stdout(output):
+                                            exit_code = cli.main(["review"])
+
+            self.assertEqual(exit_code, 1)
+            rendered = output.getvalue()
+            self.assertIn("merge_result: blocked", rendered)
+            self.assertIn(f"has blocking label(s): {config.labels['blocked']}", rendered)
+            client.merge_pull_request.assert_not_called()
+            client.update_issue_labels.assert_any_call(33, add=[config.labels["blocked"]])
+            client.update_issue_labels.assert_any_call(33, remove=[config.labels["reviewing"]])
+
+            saved_state = store.load_state()
+            self.assertEqual(saved_state.phase, "idle")
+            self.assertEqual(saved_state.last_result, "blocked")
+            self.assertEqual(saved_state.last_mission.issue_number, 33)
+            self.assertEqual(saved_state.last_mission.conclusion, "blocked")
+            self.assertIsNone(store.load_lock())
+
     def test_review_successful_ci_finalizes_needs_human_when_merge_command_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)
@@ -7137,6 +7228,35 @@ class ReviewerTest(unittest.TestCase):
                     "changed files 5 exceed max_changed_files 4",
                     "total changed lines 16 exceed max_lines_changed 10",
                 ],
+            ),
+        )
+
+    def test_evaluate_merge_stops_for_human_stop_labels(self) -> None:
+        config = Config(repo="owner/repo")
+
+        decision = evaluate_merge(
+            config=config,
+            state=State(review_loop_count=0),
+            issue={
+                "number": 34,
+                "labels": [
+                    {"name": "shinobi:reviewing"},
+                    {"name": "shinobi:blocked"},
+                ],
+            },
+            ci_status=CIStatus(
+                checks=[PullRequestCheck(name="test", state="SUCCESS", bucket="pass")],
+                status="success",
+            ),
+            diff_stats=DiffStats(changed_files=1, added_lines=2, deleted_lines=1),
+        )
+
+        self.assertEqual(
+            decision,
+            MergeDecision(
+                should_merge=False,
+                reasons=["issue #34 has blocking label(s): shinobi:blocked"],
+                conclusion="blocked",
             ),
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -592,32 +592,36 @@ class CliTest(unittest.TestCase):
                                 ),
                             ) as collect_diff_stats_mock:
                                 with patch(
-                                    "shinobi.cli.wait_for_ci",
-                                    return_value=CIStatus(
-                                        checks=[
-                                            PullRequestCheck(
-                                                name="test",
-                                                state="SUCCESS",
-                                                bucket="pass",
-                                            )
-                                        ],
-                                        status="success",
-                                    ),
-                                ) as wait_for_ci_mock:
+                                    "shinobi.cli.collect_paths_against_base_ref",
+                                    return_value=["src/shinobi/cli.py"],
+                                ):
                                     with patch(
-                                        "shinobi.cli.load_current_branch",
-                                        return_value="feature/issue-33-review-ci",
-                                    ):
-                                        with redirect_stdout(output):
-                                            exit_code = cli.main(
-                                                [
-                                                    "review",
-                                                    "--timeout-seconds",
-                                                    "30",
-                                                    "--poll-interval-seconds",
-                                                    "5",
-                                                ]
-                                            )
+                                        "shinobi.cli.wait_for_ci",
+                                        return_value=CIStatus(
+                                            checks=[
+                                                PullRequestCheck(
+                                                    name="test",
+                                                    state="SUCCESS",
+                                                    bucket="pass",
+                                                )
+                                            ],
+                                            status="success",
+                                        ),
+                                    ) as wait_for_ci_mock:
+                                        with patch(
+                                            "shinobi.cli.load_current_branch",
+                                            return_value="feature/issue-33-review-ci",
+                                        ):
+                                            with redirect_stdout(output):
+                                                exit_code = cli.main(
+                                                    [
+                                                        "review",
+                                                        "--timeout-seconds",
+                                                        "30",
+                                                        "--poll-interval-seconds",
+                                                        "5",
+                                                    ]
+                                                )
 
             self.assertEqual(exit_code, 0)
             rendered = output.getvalue()
@@ -712,24 +716,28 @@ class CliTest(unittest.TestCase):
                                 ),
                             ):
                                 with patch(
-                                    "shinobi.cli.wait_for_ci",
-                                    return_value=CIStatus(
-                                        checks=[
-                                            PullRequestCheck(
-                                                name="test",
-                                                state="SUCCESS",
-                                                bucket="pass",
-                                            )
-                                        ],
-                                        status="success",
-                                    ),
+                                    "shinobi.cli.collect_paths_against_base_ref",
+                                    return_value=["src/shinobi/cli.py"],
                                 ):
                                     with patch(
-                                        "shinobi.cli.load_current_branch",
-                                        return_value="feature/issue-33-review-ci",
+                                        "shinobi.cli.wait_for_ci",
+                                        return_value=CIStatus(
+                                            checks=[
+                                                PullRequestCheck(
+                                                    name="test",
+                                                    state="SUCCESS",
+                                                    bucket="pass",
+                                                )
+                                            ],
+                                            status="success",
+                                        ),
                                     ):
-                                        with redirect_stdout(output):
-                                            exit_code = cli.main(["review"])
+                                        with patch(
+                                            "shinobi.cli.load_current_branch",
+                                            return_value="feature/issue-33-review-ci",
+                                        ):
+                                            with redirect_stdout(output):
+                                                exit_code = cli.main(["review"])
 
             self.assertEqual(exit_code, 1)
             rendered = output.getvalue()
@@ -803,24 +811,28 @@ class CliTest(unittest.TestCase):
                                 ),
                             ):
                                 with patch(
-                                    "shinobi.cli.wait_for_ci",
-                                    return_value=CIStatus(
-                                        checks=[
-                                            PullRequestCheck(
-                                                name="test",
-                                                state="SUCCESS",
-                                                bucket="pass",
-                                            )
-                                        ],
-                                        status="success",
-                                    ),
+                                    "shinobi.cli.collect_paths_against_base_ref",
+                                    return_value=["src/shinobi/cli.py"],
                                 ):
                                     with patch(
-                                        "shinobi.cli.load_current_branch",
-                                        return_value="feature/issue-33-review-ci",
+                                        "shinobi.cli.wait_for_ci",
+                                        return_value=CIStatus(
+                                            checks=[
+                                                PullRequestCheck(
+                                                    name="test",
+                                                    state="SUCCESS",
+                                                    bucket="pass",
+                                                )
+                                            ],
+                                            status="success",
+                                        ),
                                     ):
-                                        with redirect_stdout(output):
-                                            exit_code = cli.main(["review"])
+                                        with patch(
+                                            "shinobi.cli.load_current_branch",
+                                            return_value="feature/issue-33-review-ci",
+                                        ):
+                                            with redirect_stdout(output):
+                                                exit_code = cli.main(["review"])
 
             self.assertEqual(exit_code, 1)
             rendered = output.getvalue()
@@ -835,6 +847,106 @@ class CliTest(unittest.TestCase):
             self.assertEqual(saved_state.last_result, "blocked")
             self.assertEqual(saved_state.last_mission.issue_number, 33)
             self.assertEqual(saved_state.last_mission.conclusion, "blocked")
+            self.assertIsNone(store.load_lock())
+
+    def test_review_successful_ci_stops_merge_for_high_risk_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            issue_number=33,
+                            pr_number=44,
+                            branch="feature/issue-33-review-ci",
+                            agent_identity=config.agent_identity,
+                            run_id="publish-run",
+                            phase="review",
+                            last_result="review-retry",
+                        )
+                    )
+
+                    output = io.StringIO()
+                    client = Mock()
+                    client.list_issue_comments.return_value = [
+                        {
+                            "id": 9001,
+                            "body": (
+                                "<!-- shinobi:mission-state\n"
+                                "issue: 33\n"
+                                "branch: feature/issue-33-review-ci\n"
+                                "phase: review\n"
+                                "pr: 44\n"
+                                "-->\n"
+                            ),
+                        }
+                    ]
+                    client.get_issue.return_value = {
+                        "number": 33,
+                        "state": "OPEN",
+                        "labels": [{"name": config.labels["reviewing"]}],
+                    }
+                    client.get_pull_request.return_value = {
+                        "number": 44,
+                        "isDraft": False,
+                        "baseRefName": "main",
+                    }
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
+                        with patch("shinobi.mission_finalize.GitHubClient", return_value=client):
+                            with patch(
+                                "shinobi.cli.collect_diff_stats",
+                                return_value=DiffStats(
+                                    changed_files=2,
+                                    added_lines=10,
+                                    deleted_lines=3,
+                                ),
+                            ):
+                                with patch(
+                                    "shinobi.cli.collect_paths_against_base_ref",
+                                    return_value=["auth/login.py", "src/shinobi/cli.py"],
+                                ):
+                                    with patch(
+                                        "shinobi.cli.wait_for_ci",
+                                        return_value=CIStatus(
+                                            checks=[
+                                                PullRequestCheck(
+                                                    name="test",
+                                                    state="SUCCESS",
+                                                    bucket="pass",
+                                                )
+                                            ],
+                                            status="success",
+                                        ),
+                                    ):
+                                        with patch(
+                                            "shinobi.cli.load_current_branch",
+                                            return_value="feature/issue-33-review-ci",
+                                        ):
+                                            with redirect_stdout(output):
+                                                exit_code = cli.main(["review"])
+
+            self.assertEqual(exit_code, 1)
+            rendered = output.getvalue()
+            self.assertIn("merge_result: needs-human", rendered)
+            self.assertIn(
+                "changed files match high-risk path(s): auth/ (files: auth/login.py)",
+                rendered,
+            )
+            client.merge_pull_request.assert_not_called()
+            client.update_issue_labels.assert_any_call(33, add=[config.labels["needs_human"]])
+            client.update_issue_labels.assert_any_call(33, remove=[config.labels["reviewing"]])
+
+            saved_state = store.load_state()
+            self.assertEqual(saved_state.phase, "idle")
+            self.assertEqual(saved_state.last_result, "needs-human")
+            self.assertEqual(saved_state.last_mission.issue_number, 33)
+            self.assertEqual(saved_state.last_mission.conclusion, "needs-human")
             self.assertIsNone(store.load_lock())
 
     def test_review_successful_ci_finalizes_needs_human_when_merge_command_fails(self) -> None:
@@ -894,24 +1006,28 @@ class CliTest(unittest.TestCase):
                                 ),
                             ):
                                 with patch(
-                                    "shinobi.cli.wait_for_ci",
-                                    return_value=CIStatus(
-                                        checks=[
-                                            PullRequestCheck(
-                                                name="test",
-                                                state="SUCCESS",
-                                                bucket="pass",
-                                            )
-                                        ],
-                                        status="success",
-                                    ),
+                                    "shinobi.cli.collect_paths_against_base_ref",
+                                    return_value=["src/shinobi/cli.py"],
                                 ):
                                     with patch(
-                                        "shinobi.cli.load_current_branch",
-                                        return_value="feature/issue-33-review-ci",
+                                        "shinobi.cli.wait_for_ci",
+                                        return_value=CIStatus(
+                                            checks=[
+                                                PullRequestCheck(
+                                                    name="test",
+                                                    state="SUCCESS",
+                                                    bucket="pass",
+                                                )
+                                            ],
+                                            status="success",
+                                        ),
                                     ):
-                                        with redirect_stdout(output):
-                                            exit_code = cli.main(["review"])
+                                        with patch(
+                                            "shinobi.cli.load_current_branch",
+                                            return_value="feature/issue-33-review-ci",
+                                        ):
+                                            with redirect_stdout(output):
+                                                exit_code = cli.main(["review"])
 
             self.assertEqual(exit_code, 1)
             rendered = output.getvalue()
@@ -987,30 +1103,34 @@ class CliTest(unittest.TestCase):
                             ),
                         ):
                             with patch(
-                                "shinobi.cli.wait_for_ci",
-                                return_value=CIStatus(
-                                    checks=[
-                                        PullRequestCheck(
-                                            name="test",
-                                            state="SUCCESS",
-                                            bucket="pass",
-                                        )
-                                    ],
-                                    status="success",
-                                ),
+                                "shinobi.cli.collect_paths_against_base_ref",
+                                return_value=["src/shinobi/cli.py"],
                             ):
                                 with patch(
-                                    "shinobi.cli.load_current_branch",
-                                    return_value="feature/issue-33-review-ci",
+                                    "shinobi.cli.wait_for_ci",
+                                    return_value=CIStatus(
+                                        checks=[
+                                            PullRequestCheck(
+                                                name="test",
+                                                state="SUCCESS",
+                                                bucket="pass",
+                                            )
+                                        ],
+                                        status="success",
+                                    ),
                                 ):
                                     with patch(
-                                        "shinobi.cli.finalize_mission",
-                                        side_effect=MissionFinalizeError(
-                                            "failed to create finalize comment on issue #33: api unavailable"
-                                        ),
+                                        "shinobi.cli.load_current_branch",
+                                        return_value="feature/issue-33-review-ci",
                                     ):
-                                        with redirect_stdout(output):
-                                            exit_code = cli.main(["review"])
+                                        with patch(
+                                            "shinobi.cli.finalize_mission",
+                                            side_effect=MissionFinalizeError(
+                                                "failed to create finalize comment on issue #33: api unavailable"
+                                            ),
+                                        ):
+                                            with redirect_stdout(output):
+                                                exit_code = cli.main(["review"])
 
             self.assertEqual(exit_code, 1)
             rendered = output.getvalue()
@@ -1174,15 +1294,19 @@ class CliTest(unittest.TestCase):
                                 ),
                             ):
                                 with patch(
-                                    "shinobi.cli.wait_for_ci",
-                                    side_effect=wait_for_ci_side_effect,
+                                    "shinobi.cli.collect_paths_against_base_ref",
+                                    return_value=["src/shinobi/cli.py"],
                                 ):
                                     with patch(
-                                        "shinobi.cli.load_current_branch",
-                                        return_value="feature/issue-33-review-ci",
+                                        "shinobi.cli.wait_for_ci",
+                                        side_effect=wait_for_ci_side_effect,
                                     ):
-                                        with redirect_stdout(io.StringIO()):
-                                            exit_code = cli.main(["review"])
+                                        with patch(
+                                            "shinobi.cli.load_current_branch",
+                                            return_value="feature/issue-33-review-ci",
+                                        ):
+                                            with redirect_stdout(io.StringIO()):
+                                                exit_code = cli.main(["review"])
 
             self.assertEqual(exit_code, 0)
             self.assertEqual(client.update_issue_comment.call_count, 3)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6952,10 +6952,37 @@ class ReviewerTest(unittest.TestCase):
                     "auto_merge is disabled in config",
                     "CI status is failure, not success",
                     "issue #34 has label shinobi:risky, requiring human merge",
-                    "review loop count 2 reached max_review_loops 2",
                     "changed files 5 exceed max_changed_files 4",
                     "total changed lines 16 exceed max_lines_changed 10",
                 ],
+            ),
+        )
+
+    def test_evaluate_merge_allows_success_after_retry_limit_is_reached(self) -> None:
+        config = Config(
+            repo="owner/repo",
+            max_review_loops=2,
+        )
+
+        decision = evaluate_merge(
+            config=config,
+            state=State(review_loop_count=2),
+            issue={
+                "number": 34,
+                "labels": [{"name": "shinobi:reviewing"}],
+            },
+            ci_status=CIStatus(
+                checks=[PullRequestCheck(name="test", state="SUCCESS", bucket="pass")],
+                status="success",
+            ),
+            diff_stats=DiffStats(changed_files=1, added_lines=2, deleted_lines=1),
+        )
+
+        self.assertEqual(
+            decision,
+            MergeDecision(
+                should_merge=True,
+                reasons=[],
             ),
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -575,6 +575,7 @@ class CliTest(unittest.TestCase):
                     client.get_pull_request.return_value = {
                         "number": 44,
                         "isDraft": True,
+                        "headRefName": "feature/issue-33-review-ci",
                         "baseRefName": "release/1.0",
                     }
                     client.convert_pull_request_to_ready.return_value = {
@@ -705,6 +706,12 @@ class CliTest(unittest.TestCase):
                             {"name": config.labels["risky"]},
                         ],
                     }
+                    client.get_pull_request.return_value = {
+                        "number": 44,
+                        "isDraft": False,
+                        "headRefName": "feature/issue-33-review-ci",
+                        "baseRefName": "main",
+                    }
                     with patch("shinobi.cli.GitHubClient", return_value=client):
                         with patch("shinobi.mission_finalize.GitHubClient", return_value=client):
                             with patch(
@@ -799,6 +806,12 @@ class CliTest(unittest.TestCase):
                             {"name": config.labels["reviewing"]},
                             {"name": config.labels["blocked"]},
                         ],
+                    }
+                    client.get_pull_request.return_value = {
+                        "number": 44,
+                        "isDraft": False,
+                        "headRefName": "feature/issue-33-review-ci",
+                        "baseRefName": "main",
                     }
                     with patch("shinobi.cli.GitHubClient", return_value=client):
                         with patch("shinobi.mission_finalize.GitHubClient", return_value=client):
@@ -895,6 +908,7 @@ class CliTest(unittest.TestCase):
                     client.get_pull_request.return_value = {
                         "number": 44,
                         "isDraft": False,
+                        "headRefName": "feature/issue-33-review-ci",
                         "baseRefName": "main",
                     }
                     with patch("shinobi.cli.GitHubClient", return_value=client):
@@ -991,6 +1005,12 @@ class CliTest(unittest.TestCase):
                         "number": 33,
                         "state": "OPEN",
                         "labels": [{"name": config.labels["reviewing"]}],
+                    }
+                    client.get_pull_request.return_value = {
+                        "number": 44,
+                        "isDraft": False,
+                        "headRefName": "feature/issue-33-review-ci",
+                        "baseRefName": "main",
                     }
                     client.merge_pull_request.side_effect = GitHubClientError(
                         "merge blocked by branch protection"
@@ -1092,6 +1112,8 @@ class CliTest(unittest.TestCase):
                     client.get_pull_request.return_value = {
                         "number": 44,
                         "isDraft": False,
+                        "headRefName": "feature/issue-33-review-ci",
+                        "baseRefName": "main",
                     }
                     with patch("shinobi.cli.GitHubClient", return_value=client):
                         with patch(
@@ -1265,6 +1287,12 @@ class CliTest(unittest.TestCase):
                         "number": 33,
                         "state": "OPEN",
                         "labels": [{"name": config.labels["reviewing"]}],
+                    }
+                    client.get_pull_request.return_value = {
+                        "number": 44,
+                        "isDraft": False,
+                        "headRefName": "feature/issue-33-review-ci",
+                        "baseRefName": "main",
                     }
 
                     def wait_for_ci_side_effect(*_args, **kwargs):
@@ -1947,6 +1975,103 @@ class CliTest(unittest.TestCase):
             client.assert_not_called()
             self.assertEqual(store.load_state().phase, "publish")
             self.assertEqual(store.load_state().last_result, "published")
+            self.assertIsNone(store.load_lock())
+
+    def test_review_aborts_when_pr_head_does_not_match_mission_branch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, config_error = store.try_load_config()
+                    self.assertIsNotNone(config, config_error)
+                    store.save_state(
+                        State(
+                            issue_number=33,
+                            pr_number=44,
+                            branch="feature/issue-33-review-ci",
+                            agent_identity=config.agent_identity,
+                            run_id="publish-run",
+                            phase="review",
+                            last_result="review-retry",
+                        )
+                    )
+
+                    output = io.StringIO()
+                    client = Mock()
+                    client.list_issue_comments.return_value = [
+                        {
+                            "id": 9001,
+                            "body": (
+                                "<!-- shinobi:mission-state\n"
+                                "issue: 33\n"
+                                "branch: feature/issue-33-review-ci\n"
+                                "phase: review\n"
+                                "pr: 44\n"
+                                "-->\n"
+                            ),
+                        }
+                    ]
+                    client.get_issue.return_value = {
+                        "number": 33,
+                        "state": "OPEN",
+                        "labels": [{"name": config.labels["reviewing"]}],
+                    }
+                    client.get_pull_request.return_value = {
+                        "number": 44,
+                        "isDraft": False,
+                        "headRefName": "feature/unexpected-head",
+                        "baseRefName": "main",
+                    }
+                    with patch("shinobi.cli.GitHubClient", return_value=client):
+                        with patch(
+                            "shinobi.cli.collect_diff_stats",
+                            return_value=DiffStats(
+                                changed_files=2,
+                                added_lines=10,
+                                deleted_lines=3,
+                            ),
+                        ) as collect_diff_stats_mock:
+                            with patch(
+                                "shinobi.cli.wait_for_ci",
+                                return_value=CIStatus(
+                                    checks=[
+                                        PullRequestCheck(
+                                            name="test",
+                                            state="SUCCESS",
+                                            bucket="pass",
+                                        )
+                                    ],
+                                    status="success",
+                                ),
+                            ):
+                                with patch(
+                                    "shinobi.cli.load_current_branch",
+                                    return_value="feature/issue-33-review-ci",
+                                ):
+                                    with redirect_stdout(output):
+                                        exit_code = cli.main(["review"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn(
+                "review aborted: PR #44 head branch feature/unexpected-head "
+                "does not match mission branch feature/issue-33-review-ci",
+                output.getvalue(),
+            )
+            collect_diff_stats_mock.assert_not_called()
+            client.merge_pull_request.assert_not_called()
+
+            saved_state = store.load_state()
+            self.assertEqual(saved_state.phase, "review")
+            self.assertEqual(saved_state.last_result, "review-error")
+            self.assertEqual(
+                saved_state.last_error,
+                "PR #44 head branch feature/unexpected-head "
+                "does not match mission branch feature/issue-33-review-ci",
+            )
             self.assertIsNone(store.load_lock())
 
     def test_review_rejects_invalid_poll_interval_before_side_effects(self) -> None:


### PR DESCRIPTION
## Summary
- add `merger.py` to evaluate auto-merge safety and execute squash merges through the GitHub client
- extend `shinobi review` to preserve pending/failed CI behavior, auto-merge safe PRs, and hand off risky or oversized missions to `needs-human`
- cover merge success and stop paths with CLI tests and update README implementation status

## Testing
- python3 -m unittest tests.test_cli
- env PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m compileall src tests

## Notes
- `shinobi:ready` currently still points at #26 even though PR #43 already exists, so this branch targets the next unclaimed open task, #39.
- Refs #39
