### PR TITLE
Refactor start phase state creation

### DIFF
--- a/src/shinobi/mission_start.py
+++ b/src/shinobi/mission_start.py
@@ -103,18 +103,12 @@ def start_mission(
         )
         raise error
 
-    active_state = State(
+    active_state = build_active_start_state(
         issue_number=issue_number,
-        pr_number=None,
         branch=branch,
-        agent_identity=config.agent_identity,
+        config=config,
         run_id=run_id,
-        phase="start",
-        review_loop_count=0,
-        retryable_local_only=False,
         lease_expires_at=lease_expires_at,
-        last_result="started",
-        last_error=None,
     )
     try:
         store.save_state(active_state)
@@ -256,18 +250,12 @@ def resume_local_only_mission(
         )
         raise error
 
-    active_state = State(
+    active_state = build_active_start_state(
         issue_number=issue_number,
-        pr_number=None,
         branch=state.branch,
-        agent_identity=config.agent_identity,
+        config=config,
         run_id=run_id,
-        phase="start",
-        review_loop_count=0,
-        retryable_local_only=False,
         lease_expires_at=lease_expires_at,
-        last_result="started",
-        last_error=None,
     )
     try:
         store.save_state(active_state)
@@ -308,6 +296,29 @@ def resume_local_only_mission(
 def build_branch_name(*, issue_number: int, issue_title: str) -> str:
     slug = slugify_issue_title(issue_title)
     return f"feature/issue-{issue_number}-{slug}"
+
+
+def build_active_start_state(
+    *,
+    issue_number: int,
+    branch: str,
+    config: Config,
+    run_id: str,
+    lease_expires_at: str,
+) -> State:
+    return State(
+        issue_number=issue_number,
+        pr_number=None,
+        branch=branch,
+        agent_identity=config.agent_identity,
+        run_id=run_id,
+        phase="start",
+        review_loop_count=0,
+        retryable_local_only=False,
+        lease_expires_at=lease_expires_at,
+        last_result="started",
+        last_error=None,
+    )
 
 
 def require_startable_issue(issue: dict, config: Config) -> int:


### PR DESCRIPTION
## Summary
- extract shared active start state construction for fresh start and local-only resume paths
- keep start phase behavior unchanged while reducing duplicate state field setup

## Testing
- python3 -m unittest tests.test_cli.CliTest.test_run_takes_over_stale_lock_and_selects_ready_issue tests.test_cli.CliTest.test_run_with_issue_resumes_same_retryable_local_only_mission tests.test_cli.MissionStartTest.test_start_mission_creates_branch_updates_state_and_labels tests.test_cli.MissionStartTest.test_start_mission_leaves_retryable_local_only_state_when_label_update_fails tests.test_cli.MissionStartTest.test_start_mission_rolls_back_labels_when_final_state_save_fails
- python3 -m unittest tests.test_cli
- env PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m compileall src tests

## Notes
- Follow-up/refactor for #26 on current main. The original #43 branch is stale against main and conflicts heavily after later lifecycle work.
