### PR TITLE
Wire execute heartbeat and self-review into run flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ shinobi review
 
 `watch` などの後続コマンドは将来候補です。
 
-現在の実装では foundations に加えて、`shinobi run` / `shinobi run --issue <id>` の select / start / publish phase と、`shinobi review` の CI polling / retry / auto-merge 判定が動作します。Issue 選択、`.shinobi/run.lock` によるローカル排他、`feature/issue-<id>-<slug>` branch 作成、start 用の machine-readable comment 投稿、検証コマンド実行、branch push、draft PR 作成または更新、publish 用の label / mission-state comment 更新、review phase の CI 待機、retry state 保存、安全条件を満たす PR の squash merge と finalize まで実装済みです。context builder の run phase 統合と、AI による review loop の自動修正は未実装です。
+現在の実装では foundations に加えて、`shinobi run` / `shinobi run --issue <id>` の select / start / publish phase と、`shinobi review` の CI polling / retry / auto-merge 判定が動作します。Issue 選択、`.shinobi/run.lock` によるローカル排他、`feature/issue-<id>-<slug>` branch 作成、start 用の machine-readable comment 投稿、execute 中の heartbeat 更新、検証コマンド実行、publish 前 self-review 記録、branch push、draft PR 作成または更新、publish 用の label / mission-state comment 更新、review phase の CI 待機、retry state 保存、安全条件を満たす PR の squash merge と finalize まで実装済みです。context builder の run phase 統合と、AI による review loop の自動修正は未実装です。
 
 ## ドキュメント構成
 
@@ -88,4 +88,4 @@ shinobi review
 
 ## 現在の状態
 
-このリポジトリは foundations 実装に加え、`run` の start / publish phase、`review` の CI polling / retry / merge 判定、context builder を持ちます。現在は `.shinobi/` の初期化、ローカル state/config の保存、`status` のローカル表示と GitHub 照合、`run` の issue 選択、stale/live lock 判定、branch 作成、start 用 comment 投稿、GitHub label の start 遷移、検証コマンド実行、branch push、draft PR 作成または更新、publish 用 comment / label / state 更新、review 用の CI 状態取得、retry state 保存、安全条件を満たす PR の squash merge、finalize、Issue 由来の最小 context 構築までを持ちます。context phase の run 統合と、AI による review loop の自動修正はこれから実装します。
+このリポジトリは foundations 実装に加え、`run` の start / publish phase、`review` の CI polling / retry / merge 判定、context builder を持ちます。現在は `.shinobi/` の初期化、ローカル state/config の保存、`status` のローカル表示と GitHub 照合、`run` の issue 選択、stale/live lock 判定、branch 作成、start 用 comment 投稿、GitHub label の start 遷移、execute 中の heartbeat 更新、検証コマンド実行、publish 前 self-review 記録、branch push、draft PR 作成または更新、publish 用 comment / label / state 更新、review 用の CI 状態取得、retry state 保存、安全条件を満たす PR の squash merge、finalize、Issue 由来の最小 context 構築までを持ちます。context phase の run 統合と、AI による review loop の自動修正はこれから実装します。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,9 +121,11 @@ src/shinobi/
 MVP の executor は、コード編集 agent の呼び出しではなく verification runner として実装します。
 
 - config の `verification_commands` から `lint`, `typecheck`, `test` を安定順で実行する
+- execute 開始前と各 verification command 実行前に heartbeat callback を呼べる
 - 各コマンドの `status`, `returncode`, `stdout`, `stderr`, `message` を保持する
 - 未定義コマンドは `not_configured` として失敗結果に含める
 - コマンド起動失敗は例外で phase 全体を落とさず `error` 結果として返す
+- publish 前に `.shinobi/templates/self-review.md` を読んだ結果を local state の構造化データとして保持できる
 - 後続の publish / review phase が使えるよう `ExecutionResult` に成功可否と変更要約の土台を持たせる
 
 ### `mission_publish.py`

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import subprocess
 import uuid
 from dataclasses import dataclass
@@ -36,6 +37,7 @@ from .mission_publish import (
     parse_mission_state_fields,
     publish_mission,
     stop_publish_for_blocking_labels,
+    upsert_mission_state_comment,
     upsert_review_comment,
 )
 from .mission_start import (
@@ -43,6 +45,7 @@ from .mission_start import (
     StartedMission,
     handoff_started_mission,
     labels_to_remove_for_transition,
+    render_start_comment,
     resume_local_only_mission,
     start_mission,
 )
@@ -1187,14 +1190,18 @@ def serialize_execution_result(execution_result: ExecutionResult) -> dict[str, A
     return {
         "commands": [
             {
-                "name": command.name,
-                "status": command.status,
-                "returncode": command.returncode,
-                "message": command.message,
+                "name": str(command.name),
+                "status": str(command.status),
+                "returncode": (
+                    command.returncode if isinstance(command.returncode, int) else None
+                ),
+                "message": (
+                    None if command.message is None else str(command.message)
+                ),
             }
             for command in execution_result.commands
         ],
-        "change_summary": execution_result.change_summary,
+        "change_summary": str(execution_result.change_summary),
     }
 
 
@@ -1361,7 +1368,13 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
                         issue=issue,
                         now=now,
                     )
-            execution_result = execute_verification(root, config)
+            execution_result = execute_started_mission(
+                root=root,
+                store=store,
+                config=config,
+                run_id=run_id,
+                started_mission=started_mission,
+            )
             handoff_failed_verification(
                 root=root,
                 store=store,
@@ -1412,6 +1425,209 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
         return 0
     finally:
         store.clear_lock(run_id)
+
+
+def execute_started_mission(
+    *,
+    root: Path,
+    store: StateStore,
+    config: Config,
+    run_id: str,
+    started_mission: StartedMission,
+) -> ExecutionResult:
+    heartbeat = build_execute_heartbeat(
+        root=root,
+        store=store,
+        config=config,
+        run_id=run_id,
+        started_mission=started_mission,
+    )
+    try:
+        execution_result = execute_verification(
+            root,
+            config,
+            heartbeat=heartbeat,
+        )
+    except (MissionPublishError, RuntimeError, ValueError) as error:
+        reason = f"Shinobi failed during execute phase: {error}"
+        handoff_started_mission(
+            root=root,
+            store=store,
+            config=config,
+            run_id=run_id,
+            started_mission=started_mission,
+            reason=reason,
+        )
+        raise MissionPublishError(reason) from error
+
+    try:
+        persist_self_review(
+            store=store,
+            config=config,
+            run_id=run_id,
+            started_mission=started_mission,
+            execution_result=execution_result,
+        )
+    except (MissionPublishError, OSError, RuntimeError, ValueError) as error:
+        reason = f"Shinobi failed during self-review before publish: {error}"
+        handoff_started_mission(
+            root=root,
+            store=store,
+            config=config,
+            run_id=run_id,
+            started_mission=started_mission,
+            reason=reason,
+        )
+        raise MissionPublishError(reason) from error
+
+    return execution_result
+
+
+def build_execute_heartbeat(
+    *,
+    root: Path,
+    store: StateStore,
+    config: Config,
+    run_id: str,
+    started_mission: StartedMission,
+) -> Callable[[], None]:
+    client = GitHubClient(root, repo=config.repo)
+
+    def heartbeat() -> None:
+        now = datetime.now(timezone.utc)
+        lease_expires_at = store.format_timestamp(
+            now + timedelta(minutes=config.mission_lease_minutes)
+        )
+        store.refresh_lock_heartbeat(
+            run_id=run_id,
+            agent_identity=config.agent_identity,
+            now=now,
+        )
+
+        state, state_error = store.try_load_state()
+        if state is None:
+            raise RuntimeError(
+                f"failed to load local state during execute heartbeat: {state_error}"
+            )
+
+        if state.phase != "start" or state.issue_number != started_mission.issue_number:
+            state = State(
+                issue_number=started_mission.issue_number,
+                pr_number=None,
+                branch=started_mission.branch,
+                agent_identity=config.agent_identity,
+                run_id=run_id,
+                phase="start",
+                review_loop_count=0,
+                retryable_local_only=False,
+                lease_expires_at=lease_expires_at,
+                last_result="started",
+                last_error=None,
+                last_mission=state.last_mission,
+                extra=state.extra,
+            )
+        else:
+            state = State(
+                issue_number=state.issue_number,
+                pr_number=state.pr_number,
+                branch=state.branch,
+                agent_identity=config.agent_identity,
+                run_id=run_id,
+                phase="start",
+                review_loop_count=state.review_loop_count,
+                retryable_local_only=False,
+                lease_expires_at=lease_expires_at,
+                last_result=state.last_result,
+                last_error=state.last_error,
+                last_mission=state.last_mission,
+                extra=state.extra,
+            )
+        try:
+            store.save_state(state)
+        except OSError as error:
+            raise RuntimeError(
+                f"failed to persist execute heartbeat state for issue "
+                f"#{started_mission.issue_number}: {error}"
+            ) from error
+
+        body = render_start_comment(
+            issue_number=started_mission.issue_number,
+            branch=started_mission.branch,
+            lease_expires_at=lease_expires_at,
+            agent_identity=config.agent_identity,
+            run_id=run_id,
+        )
+        try:
+            upsert_mission_state_comment(
+                client=client,
+                issue_number=started_mission.issue_number,
+                branch=started_mission.branch,
+                body=body,
+                error_prefix="failed to upsert execute mission-state comment",
+            )
+        except MissionPublishError as error:
+            raise RuntimeError(str(error)) from error
+
+    return heartbeat
+
+
+def persist_self_review(
+    *,
+    store: StateStore,
+    config: Config,
+    run_id: str,
+    started_mission: StartedMission,
+    execution_result: ExecutionResult,
+) -> None:
+    state, state_error = store.try_load_state()
+    if state is None:
+        raise RuntimeError(f"failed to load local state before self-review: {state_error}")
+
+    template_path = store.paths.self_review_template_path
+    try:
+        template = template_path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise RuntimeError(f"failed to read self-review template: {error}") from error
+
+    checklist_items = parse_self_review_checklist(template)
+    if not checklist_items:
+        raise RuntimeError("self-review template does not contain checklist items")
+
+    lease_expires_at = store.format_timestamp(
+        datetime.now(timezone.utc) + timedelta(minutes=config.mission_lease_minutes)
+    )
+    self_review = {
+        "status": "recorded",
+        "template_path": ".shinobi/templates/self-review.md",
+        "checklist_items": checklist_items,
+        "checklist_item_count": len(checklist_items),
+        "verification": serialize_execution_result(execution_result),
+    }
+    store.save_state(
+        State(
+            issue_number=state.issue_number or started_mission.issue_number,
+            pr_number=state.pr_number,
+            branch=state.branch or started_mission.branch,
+            agent_identity=config.agent_identity,
+            run_id=run_id,
+            phase="start",
+            review_loop_count=state.review_loop_count,
+            retryable_local_only=False,
+            lease_expires_at=lease_expires_at,
+            last_result=state.last_result,
+            last_error=state.last_error,
+            last_mission=state.last_mission,
+            extra={**state.extra, "self_review": self_review},
+        )
+    )
+
+
+def parse_self_review_checklist(template: str) -> list[str]:
+    return [
+        match.group(1).strip()
+        for line in template.splitlines()
+        if (match := re.match(r"^- \[[ xX]\]\s+(.*)$", line.strip())) is not None
+    ]
 
 
 def detect_local_mission_conflict(*, state: State, requested_issue: Optional[int]) -> str | None:

--- a/src/shinobi/executor.py
+++ b/src/shinobi/executor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-from typing import Iterable
+from typing import Callable, Iterable
 
 from .models import Config, ExecutionResult, StopDecision, VerificationCommandResult
 
@@ -10,9 +10,19 @@ from .models import Config, ExecutionResult, StopDecision, VerificationCommandRe
 VERIFICATION_ORDER = ("lint", "typecheck", "test")
 
 
-def execute_verification(root: Path, config: Config) -> ExecutionResult:
+def execute_verification(
+    root: Path,
+    config: Config,
+    *,
+    heartbeat: Callable[[], None] | None = None,
+) -> ExecutionResult:
     results = [
-        run_verification_command(root, name, config.verification_commands.get(name, []))
+        run_verification_command(
+            root,
+            name,
+            config.verification_commands.get(name, []),
+            heartbeat=heartbeat,
+        )
         for name in VERIFICATION_ORDER
     ]
     return ExecutionResult(
@@ -200,7 +210,12 @@ def run_verification_command(
     root: Path,
     name: str,
     command: list[str],
+    *,
+    heartbeat: Callable[[], None] | None = None,
 ) -> VerificationCommandResult:
+    if heartbeat is not None:
+        heartbeat()
+
     if not command:
         return VerificationCommandResult(
             name=name,

--- a/src/shinobi/mission_publish.py
+++ b/src/shinobi/mission_publish.py
@@ -204,6 +204,7 @@ def publish_mission(
         lease_expires_at=lease_expires_at,
         last_result="published",
         last_error=None,
+        extra=state.extra,
     )
     try:
         store.save_state(published_state)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,6 +49,7 @@ from shinobi.mission_start import (
     MissionStartError,
     StartedMission,
     handoff_started_mission,
+    render_start_comment,
     resume_local_only_mission,
     start_mission,
 )
@@ -2508,6 +2509,354 @@ class CliTest(unittest.TestCase):
             self.assertIn("test: failed", handoff_mock.call_args.kwargs["reason"])
             publish_mock.assert_not_called()
             self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
+
+    def test_run_persists_self_review_before_publish(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    output = io.StringIO()
+                    started_mission = Mock(
+                        branch="feature/issue-6-run-start-phase",
+                        issue_number=6,
+                        lease_expires_at="2026-04-09T00:30:00Z",
+                    )
+                    published_mission = Mock(
+                        branch="feature/issue-6-run-start-phase",
+                        issue_number=6,
+                        pr_number=31,
+                        pr_url="https://github.com/owner/repo/pull/31",
+                        lease_expires_at="2026-04-09T00:30:00Z",
+                    )
+                    execution_result = ExecutionResult(
+                        commands=[
+                            VerificationCommandResult(
+                                name="lint",
+                                command=[],
+                                status="not_configured",
+                                message="verification command `lint` is not configured",
+                            ),
+                            VerificationCommandResult(
+                                name="typecheck",
+                                command=["python3", "-m", "compileall"],
+                                status="passed",
+                                returncode=0,
+                            ),
+                            VerificationCommandResult(
+                                name="test",
+                                command=["python3", "-m", "unittest"],
+                                status="passed",
+                                returncode=0,
+                            ),
+                        ],
+                        change_summary="Changed auth flow.",
+                    )
+                    fake_client = FakeGitHubClient(
+                        issue_number=6,
+                        title="Run start phase",
+                        labels=["shinobi:working"],
+                    )
+
+                    def start_mission_side_effect(**kwargs):
+                        fake_client.create_issue_comment(
+                            6,
+                            render_start_comment(
+                                issue_number=6,
+                                branch=started_mission.branch,
+                                lease_expires_at=started_mission.lease_expires_at,
+                                agent_identity=kwargs["config"].agent_identity,
+                                run_id=kwargs["run_id"],
+                            ),
+                        )
+                        store.save_state(
+                            State(
+                                issue_number=6,
+                                pr_number=None,
+                                branch=started_mission.branch,
+                                agent_identity=kwargs["config"].agent_identity,
+                                run_id=kwargs["run_id"],
+                                phase="start",
+                                review_loop_count=0,
+                                retryable_local_only=False,
+                                lease_expires_at=started_mission.lease_expires_at,
+                                last_result="started",
+                                last_error=None,
+                            )
+                        )
+                        return started_mission
+
+                    with patch("shinobi.cli.list_open_issues_with_any_label", return_value=[]):
+                        with patch("shinobi.cli.select_ready_issue", return_value=6):
+                            with patch(
+                                "shinobi.cli.load_issue",
+                                return_value={"number": 6, "title": "Run start phase"},
+                            ):
+                                with patch(
+                                    "shinobi.cli.start_mission",
+                                    side_effect=start_mission_side_effect,
+                                ):
+                                    with patch(
+                                        "shinobi.cli.execute_verification",
+                                        return_value=execution_result,
+                                    ):
+                                        with patch(
+                                            "shinobi.cli.GitHubClient",
+                                            return_value=fake_client,
+                                        ):
+                                            with patch(
+                                                "shinobi.cli.load_publishable_issue_label_names",
+                                                return_value={"shinobi:working"},
+                                            ):
+                                                with patch(
+                                                    "shinobi.cli.detect_high_risk_stop",
+                                                    return_value=None,
+                                                ):
+                                                    with patch(
+                                                        "shinobi.cli.publish_mission",
+                                                        return_value=published_mission,
+                                                    ) as publish_mock:
+                                                        with redirect_stdout(output):
+                                                            exit_code = cli.main(["run"])
+
+            self.assertEqual(exit_code, 0)
+            self.assertIn("published_pr: #31", output.getvalue())
+            publish_mock.assert_called_once()
+            saved_state = store.load_state()
+            self.assertIn("self_review", saved_state.extra)
+            self.assertEqual(saved_state.extra["self_review"]["status"], "recorded")
+            self.assertEqual(
+                saved_state.extra["self_review"]["template_path"],
+                ".shinobi/templates/self-review.md",
+            )
+            self.assertGreater(saved_state.extra["self_review"]["checklist_item_count"], 0)
+            self.assertEqual(
+                saved_state.extra["self_review"]["verification"]["change_summary"],
+                "Changed auth flow.",
+            )
+
+    def test_run_hands_off_when_self_review_template_is_invalid(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    store.paths.self_review_template_path.write_text(
+                        "# invalid self review\n",
+                        encoding="utf-8",
+                    )
+                    output = io.StringIO()
+                    started_mission = Mock(
+                        branch="feature/issue-6-run-start-phase",
+                        issue_number=6,
+                        lease_expires_at="2026-04-09T00:30:00Z",
+                    )
+                    execution_result = ExecutionResult(
+                        commands=[
+                            VerificationCommandResult(
+                                name="test",
+                                command=["python3", "-m", "unittest"],
+                                status="passed",
+                                returncode=0,
+                            )
+                        ],
+                        change_summary="Changed auth flow.",
+                    )
+                    fake_client = FakeGitHubClient(
+                        issue_number=6,
+                        title="Run start phase",
+                        labels=["shinobi:working"],
+                    )
+
+                    def start_mission_side_effect(**kwargs):
+                        fake_client.create_issue_comment(
+                            6,
+                            render_start_comment(
+                                issue_number=6,
+                                branch=started_mission.branch,
+                                lease_expires_at=started_mission.lease_expires_at,
+                                agent_identity=kwargs["config"].agent_identity,
+                                run_id=kwargs["run_id"],
+                            ),
+                        )
+                        store.save_state(
+                            State(
+                                issue_number=6,
+                                pr_number=None,
+                                branch=started_mission.branch,
+                                agent_identity=kwargs["config"].agent_identity,
+                                run_id=kwargs["run_id"],
+                                phase="start",
+                                review_loop_count=0,
+                                retryable_local_only=False,
+                                lease_expires_at=started_mission.lease_expires_at,
+                                last_result="started",
+                                last_error=None,
+                            )
+                        )
+                        return started_mission
+
+                    with patch("shinobi.cli.list_open_issues_with_any_label", return_value=[]):
+                        with patch("shinobi.cli.select_ready_issue", return_value=6):
+                            with patch(
+                                "shinobi.cli.load_issue",
+                                return_value={"number": 6, "title": "Run start phase"},
+                            ):
+                                with patch(
+                                    "shinobi.cli.start_mission",
+                                    side_effect=start_mission_side_effect,
+                                ):
+                                    with patch(
+                                        "shinobi.cli.execute_verification",
+                                        return_value=execution_result,
+                                    ):
+                                        with patch(
+                                            "shinobi.cli.GitHubClient",
+                                            return_value=fake_client,
+                                        ):
+                                            with patch(
+                                                "shinobi.cli.handoff_started_mission"
+                                            ) as handoff_mock:
+                                                with patch(
+                                                    "shinobi.cli.publish_mission"
+                                                ) as publish_mock:
+                                                    with redirect_stdout(output):
+                                                        exit_code = cli.main(["run"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn(
+                "run aborted: Shinobi failed during self-review before publish: "
+                "self-review template does not contain checklist items",
+                output.getvalue(),
+            )
+            handoff_mock.assert_called_once()
+            self.assertIn(
+                "self-review template does not contain checklist items",
+                handoff_mock.call_args.kwargs["reason"],
+            )
+            publish_mock.assert_not_called()
+            self.assertEqual(store.paths.lock_path.read_text(encoding="utf-8"), "")
+
+    def test_run_execute_heartbeat_updates_start_state_and_comment(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    output = io.StringIO()
+                    fake_client = FakeGitHubClient(
+                        issue_number=6,
+                        title="Run start phase",
+                        labels=["shinobi:working"],
+                    )
+                    fake_client.create_issue_comment(
+                        6,
+                        render_start_comment(
+                            issue_number=6,
+                            branch="feature/issue-6-run-start-phase",
+                            lease_expires_at="2026-04-09T00:30:00Z",
+                            agent_identity="owner/repo#default@test",
+                            run_id="old-run",
+                        ),
+                    )
+                    started_mission = Mock(
+                        branch="feature/issue-6-run-start-phase",
+                        issue_number=6,
+                        lease_expires_at="2026-04-09T00:30:00Z",
+                    )
+                    published_mission = Mock(
+                        branch="feature/issue-6-run-start-phase",
+                        issue_number=6,
+                        pr_number=31,
+                        pr_url="https://github.com/owner/repo/pull/31",
+                        lease_expires_at="2026-04-09T00:30:00Z",
+                    )
+                    execution_result = ExecutionResult(
+                        commands=[
+                            VerificationCommandResult(
+                                name="test",
+                                command=["python3", "-m", "unittest"],
+                                status="passed",
+                                returncode=0,
+                            )
+                        ],
+                        change_summary="Changed auth flow.",
+                    )
+
+                    def start_mission_side_effect(**kwargs):
+                        store.save_state(
+                            State(
+                                issue_number=6,
+                                pr_number=None,
+                                branch=started_mission.branch,
+                                agent_identity=kwargs["config"].agent_identity,
+                                run_id=kwargs["run_id"],
+                                phase="start",
+                                review_loop_count=0,
+                                retryable_local_only=False,
+                                lease_expires_at=started_mission.lease_expires_at,
+                                last_result="started",
+                                last_error=None,
+                            )
+                        )
+                        return started_mission
+
+                    def execute_verification_side_effect(*args, **kwargs):
+                        kwargs["heartbeat"]()
+                        kwargs["heartbeat"]()
+                        return execution_result
+
+                    with patch("shinobi.cli.list_open_issues_with_any_label", return_value=[]):
+                        with patch("shinobi.cli.select_ready_issue", return_value=6):
+                            with patch(
+                                "shinobi.cli.load_issue",
+                                return_value={"number": 6, "title": "Run start phase"},
+                            ):
+                                with patch(
+                                    "shinobi.cli.start_mission",
+                                    side_effect=start_mission_side_effect,
+                                ):
+                                    with patch(
+                                        "shinobi.cli.execute_verification",
+                                        side_effect=execute_verification_side_effect,
+                                    ) as execute_mock:
+                                        with patch(
+                                            "shinobi.cli.GitHubClient",
+                                            return_value=fake_client,
+                                        ):
+                                            with patch(
+                                                "shinobi.cli.load_publishable_issue_label_names",
+                                                return_value={"shinobi:working"},
+                                            ):
+                                                with patch(
+                                                    "shinobi.cli.detect_high_risk_stop",
+                                                    return_value=None,
+                                                ):
+                                                    with patch(
+                                                        "shinobi.cli.publish_mission",
+                                                        return_value=published_mission,
+                                                    ):
+                                                        with redirect_stdout(output):
+                                                            exit_code = cli.main(["run"])
+
+            self.assertEqual(exit_code, 0)
+            self.assertTrue(execute_mock.called)
+            self.assertEqual(len(fake_client.comments), 1)
+            self.assertIn("phase: start", fake_client.comments[0]["body"])
+            saved_state = store.load_state()
+            self.assertEqual(saved_state.phase, "start")
+            self.assertNotEqual(saved_state.lease_expires_at, "2026-04-09T00:30:00Z")
+            lock = store.load_lock()
+            self.assertIsNone(lock)
 
     def test_run_hands_off_when_high_risk_paths_are_detected_before_publish(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -7425,6 +7774,35 @@ class ExecutorTest(unittest.TestCase):
             [call.args[0] for call in run_mock.call_args_list],
             [["lint-command"], ["typecheck-command"], ["test-command"]],
         )
+
+    def test_execute_verification_calls_heartbeat_before_each_command(self) -> None:
+        config = Config(
+            repo="owner/repo",
+            verification_commands={
+                "lint": ["lint-command"],
+                "typecheck": ["typecheck-command"],
+                "test": ["test-command"],
+            },
+        )
+        responses = [
+            subprocess.CompletedProcess(args=["lint-command"], returncode=0, stdout="", stderr=""),
+            subprocess.CompletedProcess(args=["typecheck-command"], returncode=0, stdout="", stderr=""),
+            subprocess.CompletedProcess(args=["test-command"], returncode=0, stdout="", stderr=""),
+        ]
+        heartbeats: list[str] = []
+
+        def heartbeat() -> None:
+            heartbeats.append("tick")
+
+        with patch("shinobi.executor.subprocess.run", side_effect=responses):
+            result = execute_verification(
+                Path("/tmp/repo"),
+                config,
+                heartbeat=heartbeat,
+            )
+
+        self.assertTrue(result.succeeded)
+        self.assertEqual(heartbeats, ["tick", "tick", "tick"])
 
     def test_collect_changed_paths_wraps_git_failures(self) -> None:
         with patch(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5747,6 +5747,101 @@ class MissionPublishTest(unittest.TestCase):
             self.assertIsNotNone(lock)
             self.assertEqual(lock.heartbeat_at, "2026-04-09T00:00:00Z")
 
+    def test_publish_mission_preserves_start_phase_extra_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+            store = StateStore(root)
+            config, _ = store.try_load_config()
+            self.assertIsNotNone(config)
+            run_id = "run-123"
+            now = datetime(2026, 4, 9, 0, 0, tzinfo=timezone.utc)
+            lock_started_at = datetime(2026, 4, 8, 23, 0, tzinfo=timezone.utc)
+            store.acquire_lock(config=config, run_id=run_id, pid=123, now=lock_started_at)
+            store.save_state(
+                cli.State(
+                    issue_number=31,
+                    pr_number=None,
+                    branch="feature/issue-31-publish-phase",
+                    agent_identity=config.agent_identity,
+                    run_id=run_id,
+                    phase="start",
+                    retryable_local_only=False,
+                    lease_expires_at="2026-04-09T00:30:00Z",
+                    last_result="started",
+                    extra={
+                        "self_review": {
+                            "status": "recorded",
+                            "template_path": ".shinobi/templates/self-review.md",
+                        }
+                    },
+                )
+            )
+            execution_result = Mock()
+            execution_result.change_summary = "Published mission changes."
+            execution_result.commands = []
+
+            with patch(
+                "shinobi.mission_publish.subprocess.run",
+                return_value=subprocess.CompletedProcess(
+                    args=["git", "push", "-u", "origin", "feature/issue-31-publish-phase"],
+                    returncode=0,
+                    stdout="",
+                    stderr="",
+                ),
+            ):
+                with patch("shinobi.mission_publish.GitHubClient") as client_cls:
+                    client = client_cls.return_value
+                    client.list_pull_requests_by_head.return_value = []
+                    client.create_pull_request.return_value = {
+                        "number": 44,
+                        "url": "https://github.com/owner/repo/pull/44",
+                    }
+                    client.get_issue.return_value = {
+                        "number": 31,
+                        "labels": [
+                            {"name": "shinobi:ready"},
+                            {"name": "shinobi:working"},
+                        ],
+                    }
+                    client.list_issue_comments.return_value = [
+                        {
+                            "id": 9001,
+                            "body": (
+                                "<!-- shinobi:mission-state\n"
+                                "issue: 31\n"
+                                "branch: feature/issue-31-publish-phase\n"
+                                "phase: start\n"
+                                "-->\n"
+                            ),
+                        }
+                    ]
+
+                    publish_mission(
+                        root=root,
+                        store=store,
+                        config=config,
+                        run_id=run_id,
+                        state=store.load_state(),
+                        execution_result=execution_result,
+                        now=now,
+                    )
+
+            state = store.load_state()
+            self.assertEqual(
+                state.extra,
+                {
+                    "self_review": {
+                        "status": "recorded",
+                        "template_path": ".shinobi/templates/self-review.md",
+                    }
+                },
+            )
+
     def test_publish_mission_updates_existing_pr(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)


### PR DESCRIPTION
## Summary
- add execute-phase heartbeat callbacks so verification can refresh the run lock, local state, and start mission-state comment
- persist structured self-review data before publish and hand off safely when the self-review template is invalid
- cover execute heartbeat and self-review flows with CLI/executor tests and update implementation docs

## Testing
- env PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m compileall src tests
- python3 -m unittest tests.test_cli

## Notes
- Refs #65
- Context phase integration remains out of scope for this PR and is tracked separately in #64
