### PR TITLE
Integrate context phase into shinobi run

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ shinobi review
 
 `watch` などの後続コマンドは将来候補です。
 
-現在の実装では foundations に加えて、`shinobi run` / `shinobi run --issue <id>` の select / start / publish phase と、`shinobi review` の CI polling / retry / auto-merge 判定が動作します。Issue 選択、`.shinobi/run.lock` によるローカル排他、`feature/issue-<id>-<slug>` branch 作成、start 用の machine-readable comment 投稿、execute 中の heartbeat 更新、検証コマンド実行、publish 前 self-review 記録、branch push、draft PR 作成または更新、publish 用の label / mission-state comment 更新、review phase の CI 待機、retry state 保存、安全条件を満たす PR の squash merge と finalize まで実装済みです。context builder の run phase 統合と、AI による review loop の自動修正は未実装です。
+現在の実装では foundations に加えて、`shinobi run` / `shinobi run --issue <id>` の select / start / context / publish phase と、`shinobi review` の CI polling / retry / auto-merge 判定が動作します。Issue 選択、`.shinobi/run.lock` によるローカル排他、`feature/issue-<id>-<slug>` branch 作成、start 用の machine-readable comment 投稿、Issue と local knowledge からの最小 context 構築、review-notes の関連カテゴリ抽出、execute 中の heartbeat 更新、検証コマンド実行、publish 前 self-review 記録、branch push、draft PR 作成または更新、publish 用の label / mission-state comment 更新、review phase の CI 待機、retry state 保存、安全条件を満たす PR の squash merge と finalize まで実装済みです。AI による review loop の自動修正は未実装です。
 
 ## ドキュメント構成
 
@@ -88,4 +88,4 @@ shinobi review
 
 ## 現在の状態
 
-このリポジトリは foundations 実装に加え、`run` の start / publish phase、`review` の CI polling / retry / merge 判定、context builder を持ちます。現在は `.shinobi/` の初期化、ローカル state/config の保存、`status` のローカル表示と GitHub 照合、`run` の issue 選択、stale/live lock 判定、branch 作成、start 用 comment 投稿、GitHub label の start 遷移、execute 中の heartbeat 更新、検証コマンド実行、publish 前 self-review 記録、branch push、draft PR 作成または更新、publish 用 comment / label / state 更新、review 用の CI 状態取得、retry state 保存、安全条件を満たす PR の squash merge、finalize、Issue 由来の最小 context 構築までを持ちます。context phase の run 統合と、AI による review loop の自動修正はこれから実装します。
+このリポジトリは foundations 実装に加え、`run` の start / context / publish phase、`review` の CI polling / retry / merge 判定、context builder を持ちます。現在は `.shinobi/` の初期化、ローカル state/config の保存、`status` のローカル表示と GitHub 照合、`run` の issue 選択、stale/live lock 判定、branch 作成、start 用 comment 投稿、GitHub label の start 遷移、Issue 由来の最小 context 構築、review-notes の関連カテゴリ抽出、context 結果の local state 保存、execute 中の heartbeat 更新、検証コマンド実行、publish 前 self-review 記録、branch push、draft PR 作成または更新、publish 用 comment / label / state 更新、review 用の CI 状態取得、retry state 保存、安全条件を満たす PR の squash merge、finalize までを持ちます。AI による review loop の自動修正はこれから実装します。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,7 +108,7 @@ src/shinobi/
 - `models.py`: ドメインモデル
 - `github_client.py`: GitHub API 操作
 - `issue_selector.py`: 次 Issue 選択
-- `context_builder.py`: 最小コンテキスト生成
+- `context_builder.py`: 最小コンテキスト生成と review-notes の関連カテゴリ抽出
 - `mission_finalize.py`: 終端 comment、label 正規化、Issue close、final state 保存、lock 解放
 - `executor.py`: 実装フェーズの検証コマンド実行と結果構造化
 - `mission_publish.py`: branch push、draft PR 作成または更新、publish 状態の label / comment / state 更新

--- a/docs/mvp-design.md
+++ b/docs/mvp-design.md
@@ -202,6 +202,7 @@ fatal 時の補償動作:
 - `.shinobi/summary.md` と `.shinobi/decisions.md` を読む
 - `.shinobi/review-notes.md` から今回の task に関連するカテゴリだけを読む
 - エージェントへ渡す実行コンテキストを構築する
+- context 結果を local state の `mission_context` に保持する
 
 設計原則:
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -237,7 +237,7 @@ shinobi watch
 - review loop
 - merge 判定
 
-実装前には `.shinobi/review-notes.md` 全体を読むのではなく、今回の task に関連するカテゴリだけを確認します。関連カテゴリが不明確な場合でも、確認対象は最大 2 カテゴリまでに抑えます。
+実装前には `.shinobi/review-notes.md` 全体を読むのではなく、今回の task に関連するカテゴリだけを確認します。`shinobi run` の context phase では、その選定結果を local state の構造化 `mission_context` として保持します。関連カテゴリが不明確な場合でも、確認対象は最大 2 カテゴリまでに抑えます。
 
 PR 前セルフレビューでは `.shinobi/templates/self-review.md` を使います。review で新しい指摘を受けた場合は、必要に応じて `.shinobi/templates/review-note-rule.md` に沿って `.shinobi/review-notes.md` へ再発防止ルールを追記します。
 

--- a/src/shinobi/cli.py
+++ b/src/shinobi/cli.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, List, Optional
 from urllib.parse import urlparse
 
 from .config import discover_workspace_root
+from .context_builder import build_mission_context
 from .executor import (
     collect_paths_against_base_ref,
     detect_high_risk_stop,
@@ -50,7 +51,7 @@ from .mission_start import (
     start_mission,
 )
 from .merger import MergerError, evaluate_merge, merge_pull_request
-from .models import Config, ExecutionResult, MissionSummary, State, StopDecision
+from .models import Config, ExecutionResult, MissionContext, MissionSummary, State, StopDecision
 from .reviewer import ReviewerError, collect_diff_stats, wait_for_ci
 from .state_store import StateStore
 
@@ -1345,10 +1346,10 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
                 return 1
 
         try:
+            issue = load_issue(root, selected_issue, repo=config.repo)
             if active_recovery is not None and active_recovery.started_mission is not None:
                 started_mission = active_recovery.started_mission
             else:
-                issue = load_issue(root, selected_issue, repo=config.repo)
                 if local_only_issue is not None:
                     started_mission = resume_local_only_mission(
                         root=root,
@@ -1368,6 +1369,14 @@ def command_run(root: Path, issue_number: Optional[int]) -> int:
                         issue=issue,
                         now=now,
                     )
+            build_and_persist_mission_context(
+                root=root,
+                store=store,
+                config=config,
+                run_id=run_id,
+                started_mission=started_mission,
+                issue=issue,
+            )
             execution_result = execute_started_mission(
                 root=root,
                 store=store,
@@ -1481,6 +1490,89 @@ def execute_started_mission(
         raise MissionPublishError(reason) from error
 
     return execution_result
+
+
+def build_and_persist_mission_context(
+    *,
+    root: Path,
+    store: StateStore,
+    config: Config,
+    run_id: str,
+    started_mission: StartedMission,
+    issue: dict[str, Any],
+) -> MissionContext:
+    try:
+        state, state_error = store.try_load_state()
+        if state is None:
+            raise RuntimeError(f"failed to load local state before context phase: {state_error}")
+        mission_context = build_mission_context(root, issue)
+        persist_mission_context(
+            store=store,
+            config=config,
+            run_id=run_id,
+            state=state,
+            started_mission=started_mission,
+            mission_context=mission_context,
+        )
+    except (OSError, RuntimeError, ValueError) as error:
+        reason = f"Shinobi failed during context phase: {error}"
+        handoff_started_mission(
+            root=root,
+            store=store,
+            config=config,
+            run_id=run_id,
+            started_mission=started_mission,
+            reason=reason,
+        )
+        raise MissionPublishError(reason) from error
+
+    if mission_context.needs_human_review:
+        reason = (
+            "Shinobi stopped before execute because context phase requires human review: "
+            f"{mission_context.needs_human_review_reason}."
+        )
+        handoff_started_mission(
+            root=root,
+            store=store,
+            config=config,
+            run_id=run_id,
+            started_mission=started_mission,
+            reason=reason,
+        )
+        raise MissionPublishError(reason)
+
+    return mission_context
+
+
+def persist_mission_context(
+    *,
+    store: StateStore,
+    config: Config,
+    run_id: str,
+    state: State,
+    started_mission: StartedMission,
+    mission_context: MissionContext,
+) -> None:
+    lease_expires_at = store.format_timestamp(
+        datetime.now(timezone.utc) + timedelta(minutes=config.mission_lease_minutes)
+    )
+    store.save_state(
+        State(
+            issue_number=state.issue_number or started_mission.issue_number,
+            pr_number=state.pr_number,
+            branch=state.branch or started_mission.branch,
+            agent_identity=config.agent_identity,
+            run_id=run_id,
+            phase="start",
+            review_loop_count=state.review_loop_count,
+            retryable_local_only=False,
+            lease_expires_at=lease_expires_at,
+            last_result=state.last_result,
+            last_error=state.last_error,
+            last_mission=state.last_mission,
+            extra={**state.extra, "mission_context": mission_context.to_dict()},
+        )
+    )
 
 
 def build_execute_heartbeat(

--- a/src/shinobi/context_builder.py
+++ b/src/shinobi/context_builder.py
@@ -324,11 +324,38 @@ def broad_scope_reason(
 
 
 def parse_review_note_sections(body: str) -> dict[str, list[str]]:
-    return {
-        key: values
-        for key, values in parse_markdown_sections(body).items()
-        if values
-    }
+    sections: dict[str, list[str]] = {}
+    current_key: str | None = None
+    current_lines: list[str] = []
+
+    for line in body.splitlines():
+        heading_match = re.match(r"^\s{0,3}(#{1,6})\s+(.+?)\s*$", line)
+        if heading_match is not None:
+            level = len(heading_match.group(1))
+            heading = heading_match.group(2).strip().lower()
+            if level == 2:
+                if current_key is not None:
+                    append_section(sections, current_key, current_lines)
+                current_key = heading
+                current_lines = []
+                continue
+            if level < 2:
+                if current_key is not None:
+                    append_section(sections, current_key, current_lines)
+                current_key = None
+                current_lines = []
+                continue
+            if current_key is not None:
+                current_lines.append(heading)
+            continue
+
+        if current_key is not None:
+            current_lines.append(line)
+
+    if current_key is not None:
+        append_section(sections, current_key, current_lines)
+
+    return {key: values for key, values in sections.items() if values}
 
 
 def select_review_note_categories(

--- a/src/shinobi/context_builder.py
+++ b/src/shinobi/context_builder.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass, field
 from pathlib import Path
 
+from .models import MissionContext
 from .state_store import StateStore
 
 
@@ -42,23 +42,54 @@ REFERENCE_SOURCE_SECTIONS = (
     "targets",
 )
 
-
-@dataclass(frozen=True)
-class MissionContext:
-    issue_number: int
-    issue_title: str
-    mission_summary: str
-    completion_criteria: list[str]
-    scope_out: list[str]
-    reference_files: list[str]
-    candidate_files: list[str]
-    prohibited_actions: list[str]
-    summary: str
-    decisions: str
-    requirements: list[str] = field(default_factory=list)
-    notes: list[str] = field(default_factory=list)
-    needs_human_review: bool = False
-    needs_human_review_reason: str | None = None
+DEFAULT_REVIEW_NOTE_CATEGORIES = ("scope-control", "state-transition")
+REVIEW_NOTE_CATEGORY_SIGNALS = {
+    "state-transition": (
+        "label",
+        "phase",
+        "state",
+        "publish",
+        "review",
+        "start",
+        "run",
+        "transition",
+        "lease",
+    ),
+    "cleanup-recovery": (
+        "cleanup",
+        "recovery",
+        "resume",
+        "retryable",
+        "stale",
+        "rollback",
+        "lock",
+        "failure",
+    ),
+    "test-coverage": (
+        "test",
+        "tests",
+        "ci",
+        "workflow",
+        "coverage",
+        "verification",
+    ),
+    "scope-control": (
+        "scope",
+        "candidate",
+        "minimal context",
+        "single task",
+        "broad",
+        "refactor",
+    ),
+    "docs-consistency": (
+        "readme",
+        "docs",
+        "spec",
+        "architecture",
+        "mvp",
+        "documentation",
+    ),
+}
 
 
 def build_mission_context(root: Path, issue: dict) -> MissionContext:
@@ -68,6 +99,9 @@ def build_mission_context(root: Path, issue: dict) -> MissionContext:
 
     summary = read_optional_text(store.paths.summary_path)
     decisions = read_optional_text(store.paths.decisions_path)
+    review_notes_sections = parse_review_note_sections(
+        read_optional_text(store.paths.review_notes_path)
+    )
     issue_paths = extract_paths_from_sections(
         sections,
         keys=REFERENCE_SOURCE_SECTIONS,
@@ -90,7 +124,14 @@ def build_mission_context(root: Path, issue: dict) -> MissionContext:
             *issue_paths,
         ]
     )
-    needs_human_review_reason = broad_scope_reason(sections, candidate_files)
+    review_note_categories = select_review_note_categories(
+        issue=issue,
+        sections=sections,
+        candidate_files=candidate_files,
+        reference_files=reference_files,
+        available_categories=list(review_notes_sections),
+    )
+    needs_human_review_reason = broad_scope_reason(body, sections, candidate_files)
 
     return MissionContext(
         issue_number=int(issue["number"]),
@@ -108,6 +149,12 @@ def build_mission_context(root: Path, issue: dict) -> MissionContext:
         decisions=decisions,
         requirements=sections.get("requirements", []),
         notes=sections.get("notes", []),
+        review_note_categories=review_note_categories,
+        review_note_entries={
+            category: review_notes_sections[category]
+            for category in review_note_categories
+            if category in review_notes_sections
+        },
         needs_human_review=needs_human_review_reason is not None,
         needs_human_review_reason=needs_human_review_reason,
     )
@@ -254,9 +301,13 @@ def derive_prohibited_actions(sections: dict[str, list[str]]) -> list[str]:
 
 
 def broad_scope_reason(
-    sections: dict[str, list[str]], candidate_files: list[str]
+    body: str,
+    sections: dict[str, list[str]],
+    candidate_files: list[str],
 ) -> str | None:
     if not candidate_files:
+        if not body.strip():
+            return None
         return "issue body does not name candidate files"
 
     scope_text = "\n".join(
@@ -270,6 +321,80 @@ def broad_scope_reason(
             return f"issue body contains broad scope marker: {word}"
 
     return None
+
+
+def parse_review_note_sections(body: str) -> dict[str, list[str]]:
+    return {
+        key: values
+        for key, values in parse_markdown_sections(body).items()
+        if values
+    }
+
+
+def select_review_note_categories(
+    *,
+    issue: dict,
+    sections: dict[str, list[str]],
+    candidate_files: list[str],
+    reference_files: list[str],
+    available_categories: list[str],
+) -> list[str]:
+    if not available_categories:
+        return []
+
+    scoring_text = "\n".join(
+        [
+            str(issue.get("title") or ""),
+            *sections.get("purpose", []),
+            *sections.get("requirements", []),
+            *sections.get("notes", []),
+            *sections.get("scope_out", []),
+            *candidate_files,
+            *reference_files,
+        ]
+    ).lower()
+
+    scored_categories: list[tuple[int, int, str]] = []
+    for index, category in enumerate(available_categories):
+        score = review_note_category_score(category, scoring_text, candidate_files, reference_files)
+        scored_categories.append((score, -index, category))
+
+    selected = [
+        category
+        for score, _, category in sorted(scored_categories, reverse=True)
+        if score > 0
+    ][:2]
+    if selected:
+        return selected
+
+    fallback = [category for category in DEFAULT_REVIEW_NOTE_CATEGORIES if category in available_categories]
+    if fallback:
+        return fallback[:2]
+    return available_categories[:2]
+
+
+def review_note_category_score(
+    category: str,
+    scoring_text: str,
+    candidate_files: list[str],
+    reference_files: list[str],
+) -> int:
+    score = 0
+    for signal in REVIEW_NOTE_CATEGORY_SIGNALS.get(category, ()):
+        score += scoring_text.count(signal)
+
+    paths = [*candidate_files, *reference_files]
+    if category == "docs-consistency" and any(
+        path == "README.md" or path.startswith("docs/") for path in paths
+    ):
+        score += 3
+    if category == "test-coverage" and any(path.startswith("tests/") for path in paths):
+        score += 3
+    if category == "scope-control" and ("broad scope" in scoring_text or "candidate" in scoring_text):
+        score += 3
+    if category == "scope-control" and not candidate_files:
+        score += 2
+    return score
 
 
 def unique_items(items: list[str]) -> list[str]:

--- a/src/shinobi/models.py
+++ b/src/shinobi/models.py
@@ -182,6 +182,33 @@ class ExecutionResult:
 
 
 @dataclass(frozen=True)
+class MissionContext:
+    issue_number: int
+    issue_title: str
+    mission_summary: str
+    completion_criteria: List[str]
+    scope_out: List[str]
+    reference_files: List[str]
+    candidate_files: List[str]
+    prohibited_actions: List[str]
+    summary: str
+    decisions: str
+    requirements: List[str] = field(default_factory=list)
+    notes: List[str] = field(default_factory=list)
+    review_note_categories: List[str] = field(default_factory=list)
+    review_note_entries: Dict[str, List[str]] = field(default_factory=dict)
+    needs_human_review: bool = False
+    needs_human_review_reason: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "MissionContext":
+        return cls(**data)
+
+
+@dataclass(frozen=True)
 class StopDecision:
     reason: str
     conclusion: str

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7889,6 +7889,39 @@ class ContextBuilderTest(unittest.TestCase):
             },
         )
 
+    def test_build_mission_context_ignores_review_notes_title_section_text(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            store = StateStore(root)
+            store.paths.shinobi_dir.mkdir()
+            store.paths.review_notes_path.write_text(
+                "# Review Notes\n\n"
+                "この説明文は category として選ばれてはならない。\n\n"
+                "## docs-consistency\n"
+                "- rule: update docs when behavior changes\n\n"
+                "## scope-control\n"
+                "- rule: keep candidate files narrow\n",
+                encoding="utf-8",
+            )
+
+            context = build_mission_context(
+                root,
+                {
+                    "number": 64,
+                    "title": "Update docs for context phase",
+                    "body": (
+                        "## 対象\n"
+                        "- `docs/product-spec.md`\n"
+                        "- `README.md`\n\n"
+                        "## 要件\n"
+                        "- context phase の説明を更新する\n"
+                    ),
+                },
+            )
+
+        self.assertEqual(context.review_note_categories, ["docs-consistency"])
+        self.assertNotIn("review notes", context.review_note_entries)
+
     def test_build_mission_context_treats_missing_knowledge_as_empty(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             context = build_mission_context(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,7 @@ from shinobi.models import (
     Config,
     DiffStats,
     ExecutionResult,
+    MissionContext,
     MissionSummary,
     PullRequestCheck,
     ReviewDecision,
@@ -2636,6 +2637,308 @@ class CliTest(unittest.TestCase):
             self.assertEqual(
                 saved_state.extra["self_review"]["verification"]["change_summary"],
                 "Changed auth flow.",
+            )
+
+    def test_run_persists_mission_context_before_publish(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    output = io.StringIO()
+                    started_mission = Mock(
+                        branch="feature/issue-6-run-start-phase",
+                        issue_number=6,
+                        lease_expires_at="2026-04-09T00:30:00Z",
+                    )
+                    published_mission = Mock(
+                        branch="feature/issue-6-run-start-phase",
+                        issue_number=6,
+                        pr_number=31,
+                        pr_url="https://github.com/owner/repo/pull/31",
+                        lease_expires_at="2026-04-09T00:30:00Z",
+                    )
+                    execution_result = ExecutionResult(
+                        commands=[
+                            VerificationCommandResult(
+                                name="test",
+                                command=["python3", "-m", "unittest"],
+                                status="passed",
+                                returncode=0,
+                            )
+                        ],
+                        change_summary="Changed auth flow.",
+                    )
+                    mission_context = MissionContext(
+                        issue_number=6,
+                        issue_title="Run start phase",
+                        mission_summary="Build run context.",
+                        completion_criteria=["context phase runs"],
+                        scope_out=["auto-fix review loop"],
+                        reference_files=[".shinobi/summary.md", "src/shinobi/cli.py"],
+                        candidate_files=["src/shinobi/cli.py", "tests/test_cli.py"],
+                        prohibited_actions=["Do not include: auto-fix review loop"],
+                        summary="summary text\n",
+                        decisions="decision text\n",
+                        review_note_categories=["state-transition", "scope-control"],
+                        review_note_entries={
+                            "state-transition": ["rule a"],
+                            "scope-control": ["rule b"],
+                        },
+                    )
+
+                    def start_mission_side_effect(**kwargs):
+                        store.save_state(
+                            State(
+                                issue_number=6,
+                                pr_number=None,
+                                branch=started_mission.branch,
+                                agent_identity=kwargs["config"].agent_identity,
+                                run_id=kwargs["run_id"],
+                                phase="start",
+                                review_loop_count=0,
+                                retryable_local_only=False,
+                                lease_expires_at=started_mission.lease_expires_at,
+                                last_result="started",
+                                last_error=None,
+                            )
+                        )
+                        return started_mission
+
+                    with patch("shinobi.cli.list_open_issues_with_any_label", return_value=[]):
+                        with patch("shinobi.cli.select_ready_issue", return_value=6):
+                            with patch(
+                                "shinobi.cli.load_issue",
+                                return_value={"number": 6, "title": "Run start phase"},
+                            ):
+                                with patch(
+                                    "shinobi.cli.start_mission",
+                                    side_effect=start_mission_side_effect,
+                                ):
+                                    with patch(
+                                        "shinobi.cli.build_mission_context",
+                                        return_value=mission_context,
+                                    ):
+                                        with patch(
+                                            "shinobi.cli.execute_verification",
+                                            return_value=execution_result,
+                                        ):
+                                            with patch(
+                                                "shinobi.cli.load_publishable_issue_label_names",
+                                                return_value={"shinobi:working"},
+                                            ):
+                                                with patch(
+                                                    "shinobi.cli.detect_high_risk_stop",
+                                                    return_value=None,
+                                                ):
+                                                    with patch(
+                                                        "shinobi.cli.publish_mission",
+                                                        return_value=published_mission,
+                                                    ):
+                                                        with redirect_stdout(output):
+                                                            exit_code = cli.main(["run"])
+
+            self.assertEqual(exit_code, 0)
+            saved_state = store.load_state()
+            self.assertEqual(
+                saved_state.extra["mission_context"]["mission_summary"],
+                "Build run context.",
+            )
+            self.assertEqual(
+                saved_state.extra["mission_context"]["review_note_categories"],
+                ["state-transition", "scope-control"],
+            )
+            self.assertEqual(
+                saved_state.extra["mission_context"]["review_note_entries"]["scope-control"],
+                ["rule b"],
+            )
+
+    def test_run_hands_off_when_context_requires_human_review(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    output = io.StringIO()
+                    started_mission = Mock(
+                        branch="feature/issue-6-run-start-phase",
+                        issue_number=6,
+                        lease_expires_at="2026-04-09T00:30:00Z",
+                    )
+                    mission_context = MissionContext(
+                        issue_number=6,
+                        issue_title="Run start phase",
+                        mission_summary="Broad task.",
+                        completion_criteria=[],
+                        scope_out=[],
+                        reference_files=[".shinobi/summary.md"],
+                        candidate_files=[],
+                        prohibited_actions=[],
+                        summary="",
+                        decisions="",
+                        needs_human_review=True,
+                        needs_human_review_reason="issue body does not name candidate files",
+                    )
+
+                    def start_mission_side_effect(**kwargs):
+                        store.save_state(
+                            State(
+                                issue_number=6,
+                                pr_number=None,
+                                branch=started_mission.branch,
+                                agent_identity=kwargs["config"].agent_identity,
+                                run_id=kwargs["run_id"],
+                                phase="start",
+                                review_loop_count=0,
+                                retryable_local_only=False,
+                                lease_expires_at=started_mission.lease_expires_at,
+                                last_result="started",
+                                last_error=None,
+                            )
+                        )
+                        return started_mission
+
+                    with patch("shinobi.cli.list_open_issues_with_any_label", return_value=[]):
+                        with patch("shinobi.cli.select_ready_issue", return_value=6):
+                            with patch(
+                                "shinobi.cli.load_issue",
+                                return_value={"number": 6, "title": "Run start phase"},
+                            ):
+                                with patch(
+                                    "shinobi.cli.start_mission",
+                                    side_effect=start_mission_side_effect,
+                                ):
+                                    with patch(
+                                        "shinobi.cli.build_mission_context",
+                                        return_value=mission_context,
+                                    ):
+                                        with patch("shinobi.cli.handoff_started_mission") as handoff_mock:
+                                            with patch("shinobi.cli.publish_mission") as publish_mock:
+                                                with redirect_stdout(output):
+                                                    exit_code = cli.main(["run"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn(
+                "run aborted: Shinobi stopped before execute because context phase requires human review",
+                output.getvalue(),
+            )
+            handoff_mock.assert_called_once()
+            self.assertIn(
+                "issue body does not name candidate files",
+                handoff_mock.call_args.kwargs["reason"],
+            )
+            publish_mock.assert_not_called()
+
+    def test_run_builds_context_when_resuming_local_only_mission(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            with patch("shinobi.config.discover_repo_slug", return_value="owner/repo"):
+                with patch("pathlib.Path.cwd", return_value=root):
+                    with redirect_stdout(io.StringIO()):
+                        cli.main(["init"])
+
+                    store = StateStore(root)
+                    config, _ = store.try_load_config()
+                    self.assertIsNotNone(config)
+                    store.save_state(
+                        State(
+                            issue_number=6,
+                            pr_number=None,
+                            branch="feature/issue-6-run-start-phase",
+                            agent_identity=config.agent_identity,
+                            run_id="previous-run",
+                            phase="start",
+                            review_loop_count=0,
+                            retryable_local_only=True,
+                            lease_expires_at=None,
+                            last_result="start_pending",
+                            last_error="retryable",
+                        )
+                    )
+                    mission_context = MissionContext(
+                        issue_number=6,
+                        issue_title="Run start phase",
+                        mission_summary="Recovered context.",
+                        completion_criteria=["resume context"],
+                        scope_out=[],
+                        reference_files=[".shinobi/summary.md"],
+                        candidate_files=["src/shinobi/cli.py"],
+                        prohibited_actions=[],
+                        summary="",
+                        decisions="",
+                    )
+                    execution_result = ExecutionResult(
+                        commands=[
+                            VerificationCommandResult(
+                                name="test",
+                                command=["python3", "-m", "unittest"],
+                                status="passed",
+                                returncode=0,
+                            )
+                        ],
+                        change_summary="Changed auth flow.",
+                    )
+                    published_mission = Mock(
+                        branch="feature/issue-6-run-start-phase",
+                        issue_number=6,
+                        pr_number=31,
+                        pr_url="https://github.com/owner/repo/pull/31",
+                        lease_expires_at="2026-04-09T00:30:00Z",
+                    )
+                    resumed_mission = Mock(
+                        branch="feature/issue-6-run-start-phase",
+                        issue_number=6,
+                        lease_expires_at="2026-04-09T00:30:00Z",
+                    )
+
+                    with patch("shinobi.cli.list_open_issues_with_any_label", return_value=[]):
+                        with patch(
+                            "shinobi.cli.recover_local_only_mission_candidate",
+                            return_value=(6, None),
+                        ):
+                            with patch("shinobi.cli.ensure_open_issue", return_value=6):
+                                with patch(
+                                    "shinobi.cli.load_issue",
+                                    return_value={"number": 6, "title": "Run start phase"},
+                                ):
+                                    with patch(
+                                        "shinobi.cli.resume_local_only_mission",
+                                        return_value=resumed_mission,
+                                    ):
+                                        with patch(
+                                            "shinobi.cli.build_mission_context",
+                                            return_value=mission_context,
+                                        ) as context_mock:
+                                            with patch(
+                                                "shinobi.cli.execute_verification",
+                                                return_value=execution_result,
+                                            ):
+                                                with patch(
+                                                    "shinobi.cli.load_publishable_issue_label_names",
+                                                    return_value={"shinobi:working"},
+                                                ):
+                                                    with patch(
+                                                        "shinobi.cli.detect_high_risk_stop",
+                                                        return_value=None,
+                                                    ):
+                                                        with patch(
+                                                            "shinobi.cli.publish_mission",
+                                                            return_value=published_mission,
+                                                        ):
+                                                            exit_code = cli.main(["run", "--issue", "6"])
+
+            self.assertEqual(exit_code, 0)
+            context_mock.assert_called_once()
+            saved_state = store.load_state()
+            self.assertEqual(
+                saved_state.extra["mission_context"]["mission_summary"],
+                "Recovered context.",
             )
 
     def test_run_hands_off_when_self_review_template_is_invalid(self) -> None:
@@ -7533,7 +7836,58 @@ class ContextBuilderTest(unittest.TestCase):
             context.prohibited_actions,
             ["Do not include: AI 実装エージェント呼び出し"],
         )
+        self.assertEqual(context.review_note_categories, [])
         self.assertFalse(context.needs_human_review)
+
+    def test_build_mission_context_reads_only_two_relevant_review_note_categories(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            store = StateStore(root)
+            store.paths.shinobi_dir.mkdir()
+            store.paths.review_notes_path.write_text(
+                "# Review Notes\n\n"
+                "## state-transition\n"
+                "- rule: preserve phase labels\n\n"
+                "## cleanup-recovery\n"
+                "- rule: verify stale recovery\n\n"
+                "## test-coverage\n"
+                "- rule: add CI tests\n\n"
+                "## scope-control\n"
+                "- rule: keep candidate files narrow\n\n"
+                "## docs-consistency\n"
+                "- rule: update docs when behavior changes\n",
+                encoding="utf-8",
+            )
+
+            context = build_mission_context(
+                root,
+                {
+                    "number": 64,
+                    "title": "Integrate context phase into shinobi run",
+                    "body": (
+                        "## 対象\n"
+                        "- `src/shinobi/cli.py`\n"
+                        "- `docs/product-spec.md`\n"
+                        "- `docs/architecture.md`\n\n"
+                        "## 要件\n"
+                        "- context phase を run に統合する\n"
+                        "- broad scope 判定を反映する\n"
+                    ),
+                },
+            )
+
+        self.assertEqual(len(context.review_note_categories), 2)
+        self.assertEqual(
+            context.review_note_categories,
+            ["docs-consistency", "scope-control"],
+        )
+        self.assertEqual(
+            context.review_note_entries,
+            {
+                "docs-consistency": ["rule: update docs when behavior changes"],
+                "scope-control": ["rule: keep candidate files narrow"],
+            },
+        )
 
     def test_build_mission_context_treats_missing_knowledge_as_empty(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary
- run start/recovery paths now build and persist structured mission context before execute
- mission context selects at most two relevant review-note categories and can stop early for broad or underspecified tasks
- update docs and tests to match the new context phase behavior

## Testing
- env PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m compileall src tests
- python3 -m unittest tests.test_cli

## Notes
- Refs #64
